### PR TITLE
support for custom data input types

### DIFF
--- a/docs/apis/visualization.md
+++ b/docs/apis/visualization.md
@@ -102,9 +102,9 @@ model_params = {
 }
 
 # The model will receive config as:
-# {"learning_rate": 0.01, "batch_size": 32, 
+# {"learning_rate": 0.01, "batch_size": 32,
 #  "optimizer": {"name": "adam", "momentum": 0.9}}
-``` 
+```
 
 ### How It Works
 

--- a/docs/apis/visualization.md
+++ b/docs/apis/visualization.md
@@ -59,6 +59,79 @@ For detailed tutorials, please refer to:
    :show-inheritance:
 ```
 
+## Custom Parameter Types
+
+Mesa's visualization system supports custom parameter types through an extractor registry. This allows you to define complex parameter structures beyond the built-in types (Slider, Checkbox, etc.).
+
+### Basic Usage
+
+Register a custom parameter extractor before creating your `SolaraViz` instance:
+
+```python
+from mesa.visualization.solara_viz import register_param_extractor
+
+def extract_dict_param(spec):
+    """Extract default values from a nested dictionary parameter."""
+    entries = spec.get("entries", {})
+    result = {}
+    for key, value in entries.items():
+        if isinstance(value, dict) and "value" in value:
+            result[key] = value["value"]
+        elif isinstance(value, dict):
+            result[key] = extract_dict_param({"entries": value})
+        else:
+            result[key] = value
+    return result
+
+# Register the extractor for "Dict" type parameters
+register_param_extractor("Dict", extract_dict_param)
+
+# Now you can use Dict type in model_params
+model_params = {
+    "config": {
+        "type": "Dict",
+        "entries": {
+            "learning_rate": {"value": 0.01},
+            "batch_size": {"value": 32},
+            "optimizer": {
+                "name": {"value": "adam"},
+                "momentum": {"value": 0.9}
+            }
+        }
+    }
+}
+
+# The model will receive config as:
+# {"learning_rate": 0.01, "batch_size": 32, 
+#  "optimizer": {"name": "adam", "momentum": 0.9}}
+``` 
+
+### How It Works
+
+When SolaraViz initializes model parameters:
+1. It checks if a parameter has a registered extractor for its "type"
+1. If found, it calls the extractor function with the parameter specification
+1. If not found, it falls back to extracting the "value" key (default behavior)
+1. This allows you to create arbitrarily complex parameter types while keeping Mesa's core simple and extensible.
+
+For a complete working example, see `mesa/examples/basic/boltzmann_wealth_model/app_with_dict_params.py` and note the way we overwrite Mesa's UserInputs with our own CustomUserInputs:
+
+```python
+# Import custom parameter support
+from custom_params import CustomUserInputs
+import mesa.visualization.solara_viz as solara_viz
+
+# Override UserInputs with CustomUserInputs
+solara_viz.UserInputs = CustomUserInputs
+```
+
+Common Use Cases
+* Nested configurations: Complex model settings organized hierarchically
+* Matrix/array parameters: Initial states for grid-based models
+* Graph structures: Network topologies as parameters
+* Custom data structures: Any domain-specific parameter format
+* Data file uploads (GeoJSON, for example) in a way that keeps the parsing logic separate from your model code
+
 
 ## Matplotlib-based visualizations
 

--- a/mesa/examples/basic/boltzmann_wealth_model/app_with_dict_params.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app_with_dict_params.py
@@ -1,0 +1,115 @@
+import altair as alt
+
+# Import custom parameter support
+from custom_params import CustomUserInputs
+
+import mesa.visualization.solara_viz as solara_viz
+from mesa.examples.basic.boltzmann_wealth_model.model import BoltzmannWealth
+from mesa.mesa_logging import INFO, log_to_stderr
+from mesa.visualization import (
+    SolaraViz,
+    SpaceRenderer,
+    make_plot_component,
+)
+from mesa.visualization.components import AgentPortrayalStyle
+
+# Override UserInputs with CustomUserInputs
+solara_viz.UserInputs = CustomUserInputs
+
+log_to_stderr(INFO)
+
+
+def agent_portrayal(agent):
+    return AgentPortrayalStyle(color=agent.wealth)
+
+
+# Modified model_params to use Dict type for grid dimensions
+model_params = {
+    "rng": {
+        "type": "InputText",
+        "value": 42,
+        "label": "Random Seed",
+    },
+    "n": {
+        "type": "SliderInt",
+        "value": 50,
+        "label": "Number of agents:",
+        "min": 10,
+        "max": 100,
+        "step": 1,
+    },
+    "grid_dimensions": {
+        "type": "Dict",
+        "label": "Grid Dimensions",
+        "entries": {
+            "width": {
+                "value": 10,
+                "label": "Width",
+                "type": "SliderInt",
+                "min": 5,
+                "max": 50,
+                "step": 1,
+            },
+            "height": {
+                "value": 10,
+                "label": "Height",
+                "type": "SliderInt",
+                "min": 5,
+                "max": 50,
+                "step": 1,
+            },
+        },
+    },
+}
+
+
+# Wrapper model to accept grid_dimensions dict
+class BoltzmannWealthWithDictParams(BoltzmannWealth):
+    def __init__(self, n=100, grid_dimensions=None, rng=None):
+        if grid_dimensions is None:
+            grid_dimensions = {"width": 10, "height": 10}
+        width = grid_dimensions["width"]
+        height = grid_dimensions["height"]
+        super().__init__(n=n, width=width, height=height, rng=rng)
+
+
+def post_process(chart):
+    """Post-process the Altair chart to add a colorbar legend."""
+    chart = chart.encode(
+        color=alt.Color(
+            "color:N",
+            scale=alt.Scale(scheme="viridis", domain=[0, 10]),
+            legend=alt.Legend(
+                title="Wealth",
+                orient="right",
+                type="gradient",
+                gradientLength=200,
+            ),
+        ),
+    )
+    return chart
+
+
+model = BoltzmannWealthWithDictParams(
+    n=50, grid_dimensions={"width": 10, "height": 10}, rng=42
+)
+
+renderer = (
+    SpaceRenderer(model, backend="altair")
+    .setup_structure(grid_color="black", grid_dash=[6, 2], grid_opacity=0.3)
+    .setup_agents(agent_portrayal, cmap="viridis", vmin=0, vmax=10)
+)
+renderer.render()
+
+renderer.post_process = post_process
+
+GiniPlot = make_plot_component("Gini")
+
+page = SolaraViz(
+    model,
+    renderer,
+    components=[GiniPlot],
+    model_params=model_params,
+    name="Boltzmann Wealth Model (Custom Dict Parameters)",
+)
+page

--- a/mesa/examples/basic/boltzmann_wealth_model/app_with_dict_params.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app_with_dict_params.py
@@ -113,4 +113,4 @@ page = SolaraViz(
     name="Boltzmann Wealth Model (Custom Dict Parameters)",
 )
 
-page
+page  # noqa

--- a/mesa/examples/basic/boltzmann_wealth_model/app_with_dict_params.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app_with_dict_params.py
@@ -112,4 +112,5 @@ page = SolaraViz(
     model_params=model_params,
     name="Boltzmann Wealth Model (Custom Dict Parameters)",
 )
-page
+
+page # noqa: F841

--- a/mesa/examples/basic/boltzmann_wealth_model/app_with_dict_params.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/app_with_dict_params.py
@@ -113,4 +113,4 @@ page = SolaraViz(
     name="Boltzmann Wealth Model (Custom Dict Parameters)",
 )
 
-page # noqa: F841
+page

--- a/mesa/examples/basic/boltzmann_wealth_model/custom_params.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/custom_params.py
@@ -78,7 +78,7 @@ def DictInput(name, options, on_change):
 
     # Render as expansion panel
     with solara.v.ExpansionPanels(v_model=[0], multiple=True):
-        with solara.v.ExpansionPanel():
+        with solara.v.ExpansionPanel(): # noqa: SIM117
             with solara.v.ExpansionPanelHeader():
                 solara.Text(f"{label}")
             with solara.v.ExpansionPanelContent():

--- a/mesa/examples/basic/boltzmann_wealth_model/custom_params.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/custom_params.py
@@ -1,0 +1,201 @@
+"""Custom parameter types and UI components for Mesa visualizations.
+
+This module demonstrates how to extend Mesa's parameter system with custom types
+using the parameter extractor registry.
+"""
+
+import solara
+
+from mesa.visualization.solara_viz import register_param_extractor
+from mesa.visualization.user_param import Slider
+
+
+def extract_dict_param(spec):
+    """Extract default values from a nested dictionary parameter specification.
+
+    This extractor handles nested dictionaries where leaf nodes have a "value" key.
+
+    Args:
+        spec: Parameter specification with structure:
+            {
+                "type": "Dict",
+                "entries": {
+                    "key1": {"value": default_value1},
+                    "key2": {"value": default_value2},
+                }
+            }
+
+    Returns:
+        dict: Extracted default values as a dictionary
+    """
+    entries = spec.get("entries", {})
+    result = {}
+
+    for key, value in entries.items():
+        if isinstance(value, dict) and "value" in value:
+            # Leaf node with explicit value
+            result[key] = value["value"]
+        elif isinstance(value, dict):
+            # Nested dictionary - recurse
+            result[key] = extract_dict_param({"entries": value})
+        else:
+            # Direct value
+            result[key] = value
+
+    return result
+
+
+# Register the Dict extractor
+register_param_extractor("Dict", extract_dict_param)
+
+
+@solara.component
+def DictInput(name, options, on_change):
+    """Render a Dict parameter as a collapsible section with individual controls.
+
+    Args:
+        name: Parameter name
+        options: Dict parameter specification with "entries"
+        on_change: Callback function for value changes
+    """
+    # State for tracking the dict values
+    dict_values = solara.use_reactive({})
+
+    # Initialize dict values from entries
+    def initialize():
+        initial_values = extract_dict_param(options)
+        dict_values.set(initial_values)
+
+    solara.use_effect(initialize, [])
+
+    # Handler for individual field changes
+    def field_change_handler(field_name, value):
+        new_dict = {**dict_values.value, field_name: value}
+        dict_values.set(new_dict)
+        on_change(name, new_dict)
+
+    label = options.get("label", name)
+
+    # Render as expansion panel
+    with solara.v.ExpansionPanels(v_model=[0], multiple=True):
+        with solara.v.ExpansionPanel():
+            with solara.v.ExpansionPanelHeader():
+                solara.Text(f"{label}")
+            with solara.v.ExpansionPanelContent():
+                entries = options.get("entries", {})
+                for key, value_spec in entries.items():
+                    if isinstance(value_spec, dict) and "value" in value_spec:
+                        # Render based on the field's metadata
+                        field_label = value_spec.get("label", key)
+                        field_type = value_spec.get("type", "InputText")
+                        current_value = dict_values.value.get(key, value_spec["value"])
+
+                        if field_type == "SliderInt":
+                            solara.SliderInt(
+                                field_label,
+                                value=current_value,
+                                on_value=lambda v, k=key: field_change_handler(k, v),
+                                min=value_spec.get("min", 0),
+                                max=value_spec.get("max", 100),
+                                step=value_spec.get("step", 1),
+                            )
+                        elif field_type == "SliderFloat":
+                            solara.SliderFloat(
+                                field_label,
+                                value=current_value,
+                                on_value=lambda v, k=key: field_change_handler(k, v),
+                                min=value_spec.get("min", 0.0),
+                                max=value_spec.get("max", 1.0),
+                                step=value_spec.get("step", 0.1),
+                            )
+                        else:
+                            # Default to text input
+                            solara.InputText(
+                                field_label,
+                                value=str(current_value),
+                                on_value=lambda v, k=key: field_change_handler(
+                                    k, int(v) if v.isdigit() else v
+                                ),
+                            )
+
+
+@solara.component
+def CustomUserInputs(user_params, on_change=None):
+    """Extended UserInputs that supports Dict type parameters.
+
+    This component extends Mesa's default UserInputs to handle custom Dict
+    parameters, rendering them as collapsible sections with individual controls.
+
+    Args:
+        user_params: Dictionary of parameter specifications
+        on_change: Callback function called with (name, value) when values change
+    """
+    for name, options in user_params.items():
+
+        def change_handler(value, name=name):
+            on_change(name, value)
+
+        # Handle Slider objects
+        if isinstance(options, Slider):
+            slider_class = (
+                solara.SliderFloat if options.is_float_slider else solara.SliderInt
+            )
+            slider_class(
+                options.label,
+                value=options.value,
+                on_value=change_handler,
+                min=options.min,
+                max=options.max,
+                step=options.step,
+            )
+            continue
+
+        # Get label and type
+        label = options.get("label", name)
+        input_type = options.get("type")
+
+        # Handle Dict type with collapsible UI
+        if input_type == "Dict":
+            DictInput(name, options, on_change)
+            continue
+
+        # Handle standard Mesa input types
+        if input_type == "SliderInt":
+            solara.SliderInt(
+                label,
+                value=options.get("value"),
+                on_value=change_handler,
+                min=options.get("min"),
+                max=options.get("max"),
+                step=options.get("step"),
+            )
+        elif input_type == "SliderFloat":
+            solara.SliderFloat(
+                label,
+                value=options.get("value"),
+                on_value=change_handler,
+                min=options.get("min"),
+                max=options.get("max"),
+                step=options.get("step"),
+            )
+        elif input_type == "Select":
+            solara.Select(
+                label,
+                value=options.get("value"),
+                on_value=change_handler,
+                values=options.get("values"),
+            )
+        elif input_type == "Checkbox":
+            solara.Checkbox(
+                label=label,
+                on_value=change_handler,
+                value=options.get("value"),
+            )
+        elif input_type == "InputText":
+            solara.InputText(
+                label=label,
+                on_value=change_handler,
+                value=options.get("value"),
+            )
+        else:
+            raise ValueError(f"{input_type} is not a supported input type")

--- a/mesa/examples/basic/boltzmann_wealth_model/custom_params.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/custom_params.py
@@ -77,46 +77,48 @@ def DictInput(name, options, on_change):
     label = options.get("label", name)
 
     # Render as expansion panel
-    with solara.v.ExpansionPanels(v_model=[0], multiple=True):
-        with solara.v.ExpansionPanel():
-            with solara.v.ExpansionPanelHeader():
-                solara.Text(f"{label}")
-            with solara.v.ExpansionPanelContent():
-                entries = options.get("entries", {})
-                for key, value_spec in entries.items():
-                    if isinstance(value_spec, dict) and "value" in value_spec:
-                        # Render based on the field's metadata
-                        field_label = value_spec.get("label", key)
-                        field_type = value_spec.get("type", "InputText")
-                        current_value = dict_values.value.get(key, value_spec["value"])
+    with (
+        solara.v.ExpansionPanels(v_model=[0], multiple=True),
+        solara.v.ExpansionPanel(),
+    ):
+        with solara.v.ExpansionPanelHeader():
+            solara.Text(f"{label}")
+        with solara.v.ExpansionPanelContent():
+            entries = options.get("entries", {})
+            for key, value_spec in entries.items():
+                if isinstance(value_spec, dict) and "value" in value_spec:
+                    # Render based on the field's metadata
+                    field_label = value_spec.get("label", key)
+                    field_type = value_spec.get("type", "InputText")
+                    current_value = dict_values.value.get(key, value_spec["value"])
 
-                        if field_type == "SliderInt":
-                            solara.SliderInt(
-                                field_label,
-                                value=current_value,
-                                on_value=lambda v, k=key: field_change_handler(k, v),
-                                min=value_spec.get("min", 0),
-                                max=value_spec.get("max", 100),
-                                step=value_spec.get("step", 1),
-                            )
-                        elif field_type == "SliderFloat":
-                            solara.SliderFloat(
-                                field_label,
-                                value=current_value,
-                                on_value=lambda v, k=key: field_change_handler(k, v),
-                                min=value_spec.get("min", 0.0),
-                                max=value_spec.get("max", 1.0),
-                                step=value_spec.get("step", 0.1),
-                            )
-                        else:
-                            # Default to text input
-                            solara.InputText(
-                                field_label,
-                                value=str(current_value),
-                                on_value=lambda v, k=key: field_change_handler(
-                                    k, int(v) if v.isdigit() else v
-                                ),
-                            )
+                    if field_type == "SliderInt":
+                        solara.SliderInt(
+                            field_label,
+                            value=current_value,
+                            on_value=lambda v, k=key: field_change_handler(k, v),
+                            min=value_spec.get("min", 0),
+                            max=value_spec.get("max", 100),
+                            step=value_spec.get("step", 1),
+                        )
+                    elif field_type == "SliderFloat":
+                        solara.SliderFloat(
+                            field_label,
+                            value=current_value,
+                            on_value=lambda v, k=key: field_change_handler(k, v),
+                            min=value_spec.get("min", 0.0),
+                            max=value_spec.get("max", 1.0),
+                            step=value_spec.get("step", 0.1),
+                        )
+                    else:
+                        # Default to text input
+                        solara.InputText(
+                            field_label,
+                            value=str(current_value),
+                            on_value=lambda v, k=key: field_change_handler(
+                                k, int(v) if v.isdigit() else v
+                            ),
+                        )
 
 
 @solara.component

--- a/mesa/examples/basic/boltzmann_wealth_model/custom_params.py
+++ b/mesa/examples/basic/boltzmann_wealth_model/custom_params.py
@@ -78,7 +78,7 @@ def DictInput(name, options, on_change):
 
     # Render as expansion panel
     with solara.v.ExpansionPanels(v_model=[0], multiple=True):
-        with solara.v.ExpansionPanel(): # noqa: SIM117
+        with solara.v.ExpansionPanel():
             with solara.v.ExpansionPanelHeader():
                 solara.Text(f"{label}")
             with solara.v.ExpansionPanelContent():

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -53,6 +53,59 @@ if TYPE_CHECKING:
 
 _mesa_logger = create_module_logger()
 
+# Parameter extractor registry for custom parameter types
+_param_extractors = {}
+
+
+def register_param_extractor(param_type: str, extractor_func: Callable):
+    """Register a custom parameter value extractor for a specific parameter type.
+
+    This allows users to define custom parameter types with complex structures
+    and provide extractors to properly initialize their default values.
+
+    Args:
+        param_type: The parameter type string (e.g., "Dict", "CustomType")
+        extractor_func: A function that takes a param_spec dict and returns the default value
+
+    Example:
+        >>> def extract_dict_param(spec):
+        ...     entries = spec.get("entries", {})
+        ...     result = {}
+        ...     for key, value in entries.items():
+        ...         if isinstance(value, dict) and "value" in value:
+        ...             result[key] = value["value"]
+        ...         elif isinstance(value, dict):
+        ...             result[key] = extract_dict_param(value)
+        ...         else:
+        ...             result[key] = value
+        ...     return result
+        ...
+        >>> register_param_extractor("Dict", extract_dict_param)
+    """
+    _param_extractors[param_type] = extractor_func
+
+
+def extract_default_value(param_spec: dict | Any) -> Any:
+    """Extract the default value from a parameter specification.
+
+    Checks registered extractors for custom parameter types before falling back
+    to the standard "value" key extraction.
+
+    Args:
+        param_spec: The parameter specification dictionary or a direct value
+
+    Returns:
+        The extracted default value
+    """
+    if not isinstance(param_spec, dict):
+        return param_spec
+
+    param_type = param_spec.get("type")
+    if param_type in _param_extractors:
+        return _param_extractors[param_type](param_spec)
+
+    return param_spec.get("value")
+
 
 @solara.component
 @function_logger(__name__)
@@ -840,7 +893,7 @@ def ModelCreator(
         lambda: model_parameters.set(
             {
                 **fixed_params,
-                **{k: v.get("value") for k, v in user_adjust_params.items()},
+                **{k: extract_default_value(v) for k, v in user_adjust_params.items()},
             }
         ),
         [],

--- a/tests/visualization/test_solara_viz.py
+++ b/tests/visualization/test_solara_viz.py
@@ -458,8 +458,8 @@ class TestRegisterParamExtractor:
             return spec.get("my_value")
 
         register_param_extractor("MyType", my_extractor)
-        assert "MyType" in _param_extractors
-        assert _param_extractors["MyType"] == my_extractor
+        assert "MyType" in solara_viz_module._param_extractors
+        assert solara_viz_module._param_extractors["MyType"] == my_extractor
 
     def test_register_multiple_extractors(self):
         """Test registering multiple extractors."""
@@ -473,9 +473,9 @@ class TestRegisterParamExtractor:
         register_param_extractor("Type1", extractor1)
         register_param_extractor("Type2", extractor2)
 
-        assert len(_param_extractors) == 2
-        assert _param_extractors["Type1"] == extractor1
-        assert _param_extractors["Type2"] == extractor2
+        assert len(solara_viz_module._param_extractors) == 2
+        assert solara_viz_module._param_extractors["Type1"] == extractor1
+        assert solara_viz_module._param_extractors["Type2"] == extractor2
 
     def test_overwrite_extractor(self):
         """Test that registering the same type overwrites the previous extractor."""
@@ -489,7 +489,7 @@ class TestRegisterParamExtractor:
         register_param_extractor("MyType", extractor1)
         register_param_extractor("MyType", extractor2)
 
-        assert _param_extractors["MyType"] == extractor2
+        assert solara_viz_module._param_extractors["MyType"] == extractor2
 
 
 class TestNestedDictExtractor:

--- a/tests/visualization/test_solara_viz.py
+++ b/tests/visualization/test_solara_viz.py
@@ -609,7 +609,7 @@ class TestBackwardCompatibility:
     def test_checkbox_param(self):
         """Test that Checkbox parameters work unchanged."""
         param_spec = {"type": "Checkbox", "value": True}
-        assert extract_default_value(param_spec) == True
+        assert extract_default_value(param_spec)
 
     def test_choice_param(self):
         """Test that Choice parameters work unchanged."""

--- a/tests/visualization/test_solara_viz.py
+++ b/tests/visualization/test_solara_viz.py
@@ -21,9 +21,20 @@ from mesa.visualization.solara_viz import (
     UserInputs,
     _build_model_init_kwargs,
     _check_model_params,
+    extract_default_value,
+    register_param_extractor,
 )
 from mesa.visualization.space_renderer import SpaceRenderer
+import mesa.visualization.solara_viz as solara_viz_module
 
+@pytest.fixture(autouse=True)
+def reset_param_extractors():
+    """Reset the parameter extractors registry before each test."""
+    original_extractors = solara_viz_module._param_extractors.copy()
+    solara_viz_module._param_extractors.clear()
+    yield
+    solara_viz_module._param_extractors.clear()
+    solara_viz_module._param_extractors.update(original_extractors)
 
 class TestMakeUserInput(unittest.TestCase):  # noqa: D101
     def test_unsupported_type(self):  # noqa: D102

--- a/tests/visualization/test_solara_viz.py
+++ b/tests/visualization/test_solara_viz.py
@@ -12,7 +12,6 @@ import mesa
 from mesa.discrete_space import CellAgent, OrthogonalMooreGrid
 from mesa.experimental.scenarios import Scenario
 import mesa.visualization.solara_viz as solara_viz_module
-from mesa.space import MultiGrid, PropertyLayer
 from mesa.visualization.backends.altair_backend import AltairBackend
 from mesa.visualization.backends.matplotlib_backend import MatplotlibBackend
 from mesa.visualization.components import AgentPortrayalStyle, PropertyLayerStyle

--- a/tests/visualization/test_solara_viz.py
+++ b/tests/visualization/test_solara_viz.py
@@ -11,6 +11,8 @@ import solara
 import mesa
 from mesa.discrete_space import CellAgent, OrthogonalMooreGrid
 from mesa.experimental.scenarios import Scenario
+import mesa.visualization.solara_viz as solara_viz_module
+from mesa.space import MultiGrid, PropertyLayer
 from mesa.visualization.backends.altair_backend import AltairBackend
 from mesa.visualization.backends.matplotlib_backend import MatplotlibBackend
 from mesa.visualization.components import AgentPortrayalStyle, PropertyLayerStyle
@@ -25,7 +27,7 @@ from mesa.visualization.solara_viz import (
     register_param_extractor,
 )
 from mesa.visualization.space_renderer import SpaceRenderer
-import mesa.visualization.solara_viz as solara_viz_module
+
 
 @pytest.fixture(autouse=True)
 def reset_param_extractors():
@@ -35,6 +37,7 @@ def reset_param_extractors():
     yield
     solara_viz_module._param_extractors.clear()
     solara_viz_module._param_extractors.update(original_extractors)
+
 
 class TestMakeUserInput(unittest.TestCase):  # noqa: D101
     def test_unsupported_type(self):  # noqa: D102
@@ -400,3 +403,285 @@ def test_parameter_splitting_logic():
     assert kwargs["scenario"].scenario_param2 == 25
     assert kwargs["model_param1"] == 15
     assert kwargs["model_param2"] == 30
+
+@pytest.fixture(autouse=True)
+def clear_extractors():
+    """Clear the extractor registry before and after each test."""
+    solara_viz_module._param_extractors.clear()
+    yield
+    solara_viz_module._param_extractors.clear()
+
+
+class TestExtractDefaultValue:
+    """Test the extract_default_value function."""
+
+    def test_extract_simple_value(self):
+        """Test extracting a simple value from a parameter spec."""
+        param_spec = {"type": "slider", "value": 10, "min": 0, "max": 100}
+        assert extract_default_value(param_spec) == 10
+
+    def test_extract_direct_value(self):
+        """Test extracting a direct value (not a dict)."""
+        assert extract_default_value(42) == 42
+        assert extract_default_value("test") == "test"
+        assert extract_default_value([1, 2, 3]) == [1, 2, 3]
+
+    def test_extract_dict_without_value_key(self):
+        """Test extracting from a dict without a 'value' key returns None."""
+        param_spec = {"type": "custom", "data": "something"}
+        assert extract_default_value(param_spec) is None
+
+    def test_extract_with_custom_extractor(self):
+        """Test that custom extractors are used when registered."""
+
+        def custom_extractor(spec):
+            return spec.get("custom_field", "default")
+
+        register_param_extractor("CustomType", custom_extractor)
+
+        param_spec = {"type": "CustomType", "custom_field": "custom_value"}
+        assert extract_default_value(param_spec) == "custom_value"
+
+    def test_fallback_to_value_key(self):
+        """Test that unregistered types fall back to 'value' key."""
+        param_spec = {"type": "UnregisteredType", "value": 123}
+        assert extract_default_value(param_spec) == 123
+
+
+class TestRegisterParamExtractor:
+    """Test the register_param_extractor function."""
+
+    def test_register_simple_extractor(self):
+        """Test registering a simple extractor."""
+
+        def my_extractor(spec):
+            return spec.get("my_value")
+
+        register_param_extractor("MyType", my_extractor)
+        assert "MyType" in _param_extractors
+        assert _param_extractors["MyType"] == my_extractor
+
+    def test_register_multiple_extractors(self):
+        """Test registering multiple extractors."""
+
+        def extractor1(spec):
+            return spec.get("value1")
+
+        def extractor2(spec):
+            return spec.get("value2")
+
+        register_param_extractor("Type1", extractor1)
+        register_param_extractor("Type2", extractor2)
+
+        assert len(_param_extractors) == 2
+        assert _param_extractors["Type1"] == extractor1
+        assert _param_extractors["Type2"] == extractor2
+
+    def test_overwrite_extractor(self):
+        """Test that registering the same type overwrites the previous extractor."""
+
+        def extractor1(spec):
+            return "first"
+
+        def extractor2(spec):
+            return "second"
+
+        register_param_extractor("MyType", extractor1)
+        register_param_extractor("MyType", extractor2)
+
+        assert _param_extractors["MyType"] == extractor2
+
+
+class TestNestedDictExtractor:
+    """Test a realistic nested dictionary extractor."""
+
+    @pytest.fixture
+    def dict_extractor(self):
+        """Fixture providing a nested dict extractor."""
+
+        def extract_dict_param(spec):
+            entries = spec.get("entries", {})
+            result = {}
+            for key, value in entries.items():
+                if isinstance(value, dict) and "value" in value:
+                    result[key] = value["value"]
+                elif isinstance(value, dict):
+                    result[key] = extract_dict_param({"entries": value})
+                else:
+                    result[key] = value
+            return result
+
+        register_param_extractor("Dict", extract_dict_param)
+        return extract_dict_param
+
+    def test_flat_dict(self, dict_extractor):
+        """Test extracting a flat dictionary."""
+        param_spec = {
+            "type": "Dict",
+            "entries": {
+                "param1": {"value": 10},
+                "param2": {"value": "test"},
+                "param3": {"value": True},
+            },
+        }
+
+        result = extract_default_value(param_spec)
+        assert result == {"param1": 10, "param2": "test", "param3": True}
+
+    def test_nested_dict(self, dict_extractor):
+        """Test extracting a nested dictionary."""
+        param_spec = {
+            "type": "Dict",
+            "entries": {
+                "learning_rate": {"value": 0.01},
+                "optimizer": {
+                    "name": {"value": "adam"},
+                    "beta1": {"value": 0.9},
+                    "beta2": {"value": 0.999},
+                },
+            },
+        }
+
+        result = extract_default_value(param_spec)
+        assert result == {
+            "learning_rate": 0.01,
+            "optimizer": {"name": "adam", "beta1": 0.9, "beta2": 0.999},
+        }
+
+    def test_deeply_nested_dict(self, dict_extractor):
+        """Test extracting a deeply nested dictionary."""
+        param_spec = {
+            "type": "Dict",
+            "entries": {"level1": {"level2": {"level3": {"value": "deep"}}}},
+        }
+
+        result = extract_default_value(param_spec)
+        assert result == {"level1": {"level2": {"level3": "deep"}}}
+
+    def test_empty_dict(self, dict_extractor):
+        """Test extracting an empty dictionary."""
+        param_spec = {"type": "Dict", "entries": {}}
+        result = extract_default_value(param_spec)
+        assert result == {}
+
+
+class TestMatrixExtractor:
+    """Test a realistic matrix extractor."""
+
+    @pytest.fixture
+    def matrix_extractor(self):
+        """Fixture providing a matrix extractor."""
+
+        def extract_matrix_param(spec):
+            rows = spec.get("rows", 3)
+            cols = spec.get("cols", 3)
+            default_value = spec.get("default_value", 0)
+            return [[default_value for _ in range(cols)] for _ in range(rows)]
+
+        register_param_extractor("Matrix", extract_matrix_param)
+        return extract_matrix_param
+
+    def test_default_matrix(self, matrix_extractor):
+        """Test creating a matrix with default dimensions."""
+        param_spec = {"type": "Matrix"}
+        result = extract_default_value(param_spec)
+        assert len(result) == 3
+        assert all(len(row) == 3 for row in result)
+        assert all(all(cell == 0 for cell in row) for row in result)
+
+    def test_custom_dimensions(self, matrix_extractor):
+        """Test creating a matrix with custom dimensions."""
+        param_spec = {"type": "Matrix", "rows": 5, "cols": 4, "default_value": 1}
+        result = extract_default_value(param_spec)
+        assert len(result) == 5
+        assert all(len(row) == 4 for row in result)
+        assert all(all(cell == 1 for cell in row) for row in result)
+
+
+class TestBackwardCompatibility:
+    """Test that existing parameter types still work."""
+
+    def test_slider_param(self):
+        """Test that Slider parameters work unchanged."""
+        param_spec = {"type": "SliderInt", "value": 50, "min": 0, "max": 100}
+        assert extract_default_value(param_spec) == 50
+
+    def test_checkbox_param(self):
+        """Test that Checkbox parameters work unchanged."""
+        param_spec = {"type": "Checkbox", "value": True}
+        assert extract_default_value(param_spec) == True
+
+    def test_choice_param(self):
+        """Test that Choice parameters work unchanged."""
+        param_spec = {
+            "type": "Choice",
+            "value": "option1",
+            "choices": ["option1", "option2"],
+        }
+        assert extract_default_value(param_spec) == "option1"
+
+    def test_fixed_param(self):
+        """Test that fixed parameters (direct values) work unchanged."""
+        assert extract_default_value(100) == 100
+        assert extract_default_value("fixed_string") == "fixed_string"
+        assert extract_default_value({"key": "value"}) is None  # No "value" key
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions."""
+
+    def test_none_param_spec(self):
+        """Test handling None as parameter spec."""
+        assert extract_default_value(None) is None
+
+    def test_extractor_raises_exception(self):
+        """Test that exceptions in extractors propagate."""
+
+        def bad_extractor(spec):
+            raise ValueError("Intentional error")
+
+        register_param_extractor("BadType", bad_extractor)
+
+        param_spec = {"type": "BadType"}
+        with pytest.raises(ValueError, match="Intentional error"):
+            extract_default_value(param_spec)
+
+    def test_extractor_returns_none(self):
+        """Test that extractors can return None."""
+
+        def none_extractor(spec):
+            return None
+
+        register_param_extractor("NoneType", none_extractor)
+
+        param_spec = {"type": "NoneType"}
+        assert extract_default_value(param_spec) is None
+
+    def test_complex_nested_structure(self):
+        """Test a complex nested structure with mixed types."""
+
+        def complex_extractor(spec):
+            data = spec.get("data", {})
+            result = {}
+            for key, value in data.items():
+                if isinstance(value, dict) and "value" in value:
+                    result[key] = value["value"]
+                elif isinstance(value, list):
+                    result[key] = [extract_default_value(item) for item in value]
+                else:
+                    result[key] = value
+            return result
+
+        register_param_extractor("Complex", complex_extractor)
+
+        param_spec = {
+            "type": "Complex",
+            "data": {
+                "simple": {"value": 42},
+                "list": [{"value": 1}, {"value": 2}, {"value": 3}],
+                "direct": "string",
+            },
+        }
+
+        result = extract_default_value(param_spec)
+        assert result == {"simple": 42, "list": [1, 2, 3], "direct": "string"}

--- a/tests/visualization/test_solara_viz.py
+++ b/tests/visualization/test_solara_viz.py
@@ -9,9 +9,9 @@ import pytest
 import solara
 
 import mesa
+import mesa.visualization.solara_viz as solara_viz_module
 from mesa.discrete_space import CellAgent, OrthogonalMooreGrid
 from mesa.experimental.scenarios import Scenario
-import mesa.visualization.solara_viz as solara_viz_module
 from mesa.visualization.backends.altair_backend import AltairBackend
 from mesa.visualization.backends.matplotlib_backend import MatplotlibBackend
 from mesa.visualization.components import AgentPortrayalStyle, PropertyLayerStyle
@@ -402,6 +402,7 @@ def test_parameter_splitting_logic():
     assert kwargs["scenario"].scenario_param2 == 25
     assert kwargs["model_param1"] == 15
     assert kwargs["model_param2"] == 30
+
 
 @pytest.fixture(autouse=True)
 def clear_extractors():


### PR DESCRIPTION
### Summary
Added support for custom parameter types in Mesa's visualization system through a parameter extractor registry. This allows users to define complex parameter structures (nested dicts, matrices, file loaders, etc.) beyond the built-in UI types.

### Motive
We found a need to keep some user inputs grouped in dict-like structures to make input a more intuitive (for example 'alpha' and 'beta' parameters to configure a beta distribution), to allow a checkbox (allow personnel turnover) to make subsequent inputs visible (how many, how often, replacement time, ...), and to create range sliders to define min/max input values. In our implementation, we made these dict input types collapsible so that we could minimize the  vertical space the user inputs take up. Mesa's visualization previously only supported simple parameter types (sliders, checkboxes, text inputs). We also wanted users to be able to upload data files or configuration files when the number of user parameters in our model became too cumbersome for drop-downs and sliders. Even when we over-wrote the 'UserInputs' we realilzed that Mesa still needed to know how to process the data when the 'Reset' button reloaded the current user params into the model. Setting up a custom data extractor registry in 'solara_viz.py' seemed the least invasive way to make our customizations generalizable for any use case. 

### Implementation
- Added `register_param_extractor()` function to register custom parameter type handlers
- Modified `extract_default_value()` to check registered extractors before falling back to standard "value" key extraction
- Updated `UserInputs` to skip rendering parameters with custom extractors that don't have standard UI components
- Added tests in `tests/visualization/test_solara_viz.py`  and made certain we didn't break anything that was already working

### Usage Examples
Added an example demonstrating the feature:
1.  **`mesa/examples/basic/boltzmann_wealth_model/app_with_dict_params.py`**: Modified Boltzmann Wealth Model using a Dict parameter to group related configuration options (**note** this also includes a `custom_params.py` file that tells Solara how to render the inputs.)

Example usage:
```python
from mesa.visualization.solara_viz import register_param_extractor

def extract_dict_param(spec):
    entries = spec.get("entries", {})
    result = {}
    for key, value in entries.items():
        if isinstance(value, dict) and "value" in value:
            result[key] = value["value"]
        elif isinstance(value, dict):
            result[key] = extract_dict_param({"entries": value})
        else:
            result[key] = value
    return result

register_param_extractor("Dict", extract_dict_param)

model_params = {
    "config": {
        "type": "Dict",
        "entries": {
            "width": {"value": 10},
            "height": {"value": 10}
        }
    }
}


<img width="564" height="537" alt="Dict param - expanded" src="https://github.com/user-attachments/assets/f88b20e0-b1ff-4415-bc78-3a6f21b0afde" />

<img width="544" height="340" alt="Dict param - collapsed" src="https://github.com/user-attachments/assets/79dd185f-506e-4545-bdeb-e96eec7c756b" />


