### PR TITLE
Adding 'is_component' Badge to meta_agent

### DIFF
--- a/mesa/experimental/meta_agents/meta_agent.py
+++ b/mesa/experimental/meta_agents/meta_agent.py
@@ -313,6 +313,8 @@ class MetaAgent(Agent):
             agent.meta_agents.add(self)
             # Maintain backward compatibility for code expecting agent.meta_agent
             agent.meta_agent = self
+            # Mark as component for parallel scheduler
+            agent.is_component = True
 
     def __len__(self) -> int:
         """Return the number of components."""
@@ -389,6 +391,8 @@ class MetaAgent(Agent):
                 agent.meta_agents = set()
             agent.meta_agents.add(self)
             agent.meta_agent = self
+            # Mark as component for parallel scheduler
+            agent.is_component = True
 
     def remove_constituting_agents(self, remove_agents: set[Agent]):
         """Remove agents as components.
@@ -407,6 +411,8 @@ class MetaAgent(Agent):
                     )[0]
                 else:
                     agent.meta_agent = None
+                    # No longer a component if not in any meta-agent
+                    agent.is_component = False
 
     def step(self):
         """Perform the agent's step.

--- a/tests/experimental/test_meta_agents.py
+++ b/tests/experimental/test_meta_agents.py
@@ -336,3 +336,52 @@ def test_find_combinations_without_evaluation_func(setup_agents):
     # This should not cause a TypeError from unpacking
     result = find_combinations(model, model.agents, size=2, evaluation_func=None)
     assert result == []  # No combinations when no evaluation function
+
+
+def test_is_component_flag_set_on_init(setup_agents):
+    """Test that is_component is set to True when an agent is added to MetaAgent on init."""
+    model, agents = setup_agents
+    agent1 = agents[0]
+
+    # Initially not set (or could be False if previously used, but here fresh agents)
+    assert not hasattr(agent1, "is_component")
+
+    MetaAgent(model, {agent1})
+
+    assert agent1.is_component is True
+
+
+def test_is_component_flag_set_on_add(setup_agents):
+    """Test that is_component is set to True when an agent is added via add_constituting_agents."""
+    model, agents = setup_agents
+    agent1 = agents[1]
+    meta = MetaAgent(model, set())
+
+    assert not hasattr(agent1, "is_component")
+
+    meta.add_constituting_agents({agent1})
+
+    assert agent1.is_component is True
+
+
+def test_is_component_flag_unset_on_remove(setup_agents):
+    """Test that is_component is set to False when an agent is removed from all meta agents."""
+    model, agents = setup_agents
+    agent1 = agents[2]
+    meta1 = MetaAgent(model, {agent1})
+
+    assert agent1.is_component is True
+
+    meta1.remove_constituting_agents({agent1})
+
+    assert agent1.is_component is False
+
+
+def test_create_meta_agent_sets_is_component(setup_agents):
+    """Test that create_meta_agent also sets the is_component flag."""
+    model, agents = setup_agents
+    agent1 = agents[0]
+
+    create_meta_agent(model, "GroupA", [agent1], Agent)
+
+    assert agent1.is_component is True

--- a/tests/experimental/test_multi_level_meta_agents.py
+++ b/tests/experimental/test_multi_level_meta_agents.py
@@ -87,3 +87,23 @@ def test_create_meta_agent_independent_groups_with_overlap():
 
     assert len(agent2.meta_agents) == 1
     assert any(ma.__class__.__name__ == "GroupB" for ma in agent2.meta_agents)
+
+
+def test_is_component_flag_remains_true_if_in_another_group_overlap():
+    """Test that is_component remains True if an agent is still in another meta agent."""
+    model = Model()
+    agent1 = Agent(model)
+    meta1 = MetaAgent(model, {agent1})
+    meta2 = MetaAgent(model, {agent1})
+
+    assert agent1.is_component is True
+
+    meta1.remove_constituting_agents({agent1})
+
+    # Still in meta2, so should remain True
+    assert agent1.is_component is True
+
+    meta2.remove_constituting_agents({agent1})
+
+    # Now removed from all, should be False
+    assert agent1.is_component is False


### PR DESCRIPTION
Fix for :https://github.com/mesa/mesa/issues/3451
is_component Badge

A boolean flag in meta_agent.py allows the scheduler to identify and skip sub-agents.

    Join: is_component = True
    The agent is marked as a component and skipped by the scheduler.

    Leave: is_component = False
    The badge is removed and the agent becomes independently schedulable again.
