### PR TITLE
align AgentDataSet with NumpyAgentDataSet by supporting agent class input

### DIFF
--- a/mesa/experimental/data_collection/dataset.py
+++ b/mesa/experimental/data_collection/dataset.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import abc
 import operator
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable, Literal
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import numpy as np
-
 
 from mesa.agent import Agent
 from mesa.agentset import AbstractAgentSet
@@ -130,7 +129,6 @@ class AgentDataSet[A: Agent](BaseDataSet):
         fields: str | list[str] | None = None,
     ):
         """Init. of AgentDataSet."""
-
         if args:
             if len(args) > 1:
                 raise TypeError("too many positional arguments")
@@ -202,7 +200,7 @@ class AgentDataSet[A: Agent](BaseDataSet):
             self._is_dirty = False
 
         return self._cache
-    
+
     def _get_agents(self):
         if self._mode == "set":
             return self._agents or []

--- a/mesa/experimental/data_collection/dataset.py
+++ b/mesa/experimental/data_collection/dataset.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import abc
 import operator
 from contextlib import suppress
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable, Literal
 
 import numpy as np
+
 
 from mesa.agent import Agent
 from mesa.agentset import AbstractAgentSet
@@ -110,7 +111,9 @@ class AgentDataSet[A: Agent](BaseDataSet):
 
     Args:
         name: the name of the data set
-        agents: the agents to collect data from
+        source: AgentSet or Agent class to collect data from
+        model: required if source is an Agent class
+        agents: optional override AgentSet (takes precedence over source)
         fields: fields to collect
         use_dirty_flag: if True, enables manual dirty-flag caching optimization.
                         Default is False (always recompute snapshot).
@@ -119,21 +122,64 @@ class AgentDataSet[A: Agent](BaseDataSet):
     def __init__(
         self,
         name: str,
-        agents: AbstractAgentSet[A],
-        *,
+        source: AbstractAgentSet[A] | type[A],
+        *args,
+        model: Model | None = None,
+        agents: AbstractAgentSet[A] | None = None,
         use_dirty_flag: bool = False,
         fields: str | list[str] | None = None,
     ):
         """Init. of AgentDataSet."""
+
+        if args:
+            if len(args) > 1:
+                raise TypeError("too many positional arguments")
+            if fields is not None:
+                raise TypeError("fields specified both positionally and as keyword")
+            fields = args[0]
+
         if fields is None:
             raise ValueError("please pass one or more fields to collect")
         elif isinstance(fields, str):
             fields = [fields]
 
+        # Base initialization
         super().__init__(name, fields=["unique_id", *fields])
-        self.agents = agents
 
-        # Dirty-flag behavior (opt-in only)
+        self._mode: Literal["set", "type"]
+        self._agents: AbstractAgentSet[A] | None
+        self._agent_type: type[A] | None
+        self._model: Model | None
+
+        if agents is not None:
+            # Explicit override always wins
+            self._mode = "set"
+            self._agents = agents
+            self._agent_type = None
+            self._model = None
+
+        elif isinstance(source, AbstractAgentSet):
+            self._mode = "set"
+            self._agents = source
+            self._agent_type = None
+            self._model = None
+
+            if model is not None:
+                raise ValueError("model should not be provided when using AgentSet")
+
+        elif isinstance(source, type) and issubclass(source, Agent):
+            if model is None:
+                raise ValueError("model must be provided when using agent class")
+
+            self._mode = "type"
+            self._agent_type = source
+            self._model = model
+            self._agents = None
+
+        else:
+            raise TypeError("source must be an AgentSet or Agent class")
+
+        # Dirty-flag behavior
         self._use_dirty_flag: bool = use_dirty_flag
         self._is_dirty: bool = True
         self._cache: list[dict[str, Any]] | None = None
@@ -146,7 +192,7 @@ class AgentDataSet[A: Agent](BaseDataSet):
         if (not self._use_dirty_flag) or self._is_dirty or self._cache is None:
             snapshot = [
                 dict(zip(self._attributes, self._collector(agent)))
-                for agent in self.agents
+                for agent in self._get_agents()
             ]
 
             if not self._use_dirty_flag:
@@ -156,6 +202,15 @@ class AgentDataSet[A: Agent](BaseDataSet):
             self._is_dirty = False
 
         return self._cache
+    
+    def _get_agents(self):
+        if self._mode == "set":
+            return self._agents or []
+
+        if self._model is None or self._agent_type is None:
+            return []
+
+        return self._model.agents_by_type.get(self._agent_type, [])
 
     def set_dirty_flag(self) -> None:
         """Mark the dataset as dirty.
@@ -171,7 +226,8 @@ class AgentDataSet[A: Agent](BaseDataSet):
     def close(self):
         """Close the data set."""
         super().close()
-        self.agents = None
+        self._agents = None
+        self._model = None
         self._cache = None
 
 

--- a/tests/experimental/test_dataset.py
+++ b/tests/experimental/test_dataset.py
@@ -622,3 +622,51 @@ def test_agent_dataset_invalid_source_type():
 
     with pytest.raises(TypeError):
         AgentDataSet("invalid", 123, fields="wealth")
+
+
+def test_agent_dataset_class_no_agents():
+    """Agent class with no instances should return empty data."""
+
+    class MyAgent(Agent):
+        def __init__(self, model):
+            super().__init__(model)
+            self.wealth = 1
+
+    model = Model()
+
+    dataset = AgentDataSet(
+        "x",
+        MyAgent,
+        model=model,
+        fields="wealth",
+    )
+
+    assert dataset.data == []
+
+
+def test_agent_dataset_close_with_class():
+    """After close(), dataset should return empty data."""
+
+    class MyAgent(Agent):
+        def __init__(self, model):
+            super().__init__(model)
+            self.wealth = 1
+
+    model = Model()
+    MyAgent(model)
+
+    dataset = AgentDataSet(
+        "x",
+        MyAgent,
+        model=model,
+        fields="wealth",
+    )
+
+    # sanity check
+    assert len(dataset.data) == 1
+
+    dataset.close()
+
+    assert dataset.data == []
+
+

--- a/tests/experimental/test_dataset.py
+++ b/tests/experimental/test_dataset.py
@@ -499,6 +499,7 @@ def test_agent_dataset_dirty_flag():
     with pytest.raises(RuntimeError):
         dataset.set_dirty_flag()
 
+
 def test_agent_dataset_with_agent_class():
     """Test AgentDataSet with agent class input."""
 
@@ -584,7 +585,6 @@ def test_agent_dataset_agents_override_with_class():
 
 def test_agent_dataset_legacy_positional_fields():
     """Test backward compatibility with positional fields argument."""
-
     model = Model()
 
     dataset = AgentDataSet("x", model.agents, "wealth")
@@ -617,9 +617,9 @@ def test_agent_dataset_dynamic_agents_with_class():
     MyAgent(model)
     assert len(dataset.data) == 2
 
+
 def test_agent_dataset_invalid_source_type():
     """Test that invalid source type raises TypeError."""
-
     with pytest.raises(TypeError):
         AgentDataSet("invalid", 123, fields="wealth")
 
@@ -668,4 +668,3 @@ def test_agent_dataset_close_with_class():
 
     with pytest.raises(RuntimeError):
         _ = dataset.data
-

--- a/tests/experimental/test_dataset.py
+++ b/tests/experimental/test_dataset.py
@@ -645,7 +645,7 @@ def test_agent_dataset_class_no_agents():
 
 
 def test_agent_dataset_close_with_class():
-    """After close(), dataset should return empty data."""
+    """After close(), accessing data should raise RuntimeError."""
 
     class MyAgent(Agent):
         def __init__(self, model):
@@ -662,11 +662,10 @@ def test_agent_dataset_close_with_class():
         fields="wealth",
     )
 
-    # sanity check
     assert len(dataset.data) == 1
 
     dataset.close()
 
-    assert dataset.data == []
-
+    with pytest.raises(RuntimeError):
+        _ = dataset.data
 

--- a/tests/experimental/test_dataset.py
+++ b/tests/experimental/test_dataset.py
@@ -162,7 +162,7 @@ def test_agent_dataset():
     dataset.close()
     with pytest.raises(RuntimeError):
         _ = dataset.data
-    assert dataset.agents is None
+    assert dataset._agents is None
 
 
 def test_numpy_agent_dataset():
@@ -498,3 +498,127 @@ def test_agent_dataset_dirty_flag():
     dataset.close()
     with pytest.raises(RuntimeError):
         dataset.set_dirty_flag()
+
+def test_agent_dataset_with_agent_class():
+    """Test AgentDataSet with agent class input."""
+
+    class MyAgent(Agent):
+        def __init__(self, model, value):
+            super().__init__(model)
+            self.wealth = value
+
+    model = Model()
+    MyAgent.create_agents(model, 5, [1, 2, 3, 4, 5])
+
+    dataset = AgentDataSet(
+        "wealth_ds",
+        MyAgent,
+        model=model,
+        fields="wealth",
+    )
+
+    data = dataset.data
+
+    assert len(data) == 5
+    assert all("wealth" in row for row in data)
+
+
+def test_agent_dataset_class_without_model_raises():
+    """Test that passing agent class without model raises error."""
+
+    class MyAgent(Agent):
+        pass
+
+    with pytest.raises(ValueError):
+        AgentDataSet("x", MyAgent, fields="wealth")
+
+
+def test_agent_dataset_agents_override_with_agentset_source():
+    """Test that agents override takes precedence over AgentSet source."""
+
+    class MyAgent(Agent):
+        def __init__(self, model, value):
+            super().__init__(model)
+            self.wealth = value
+
+    model = Model()
+    MyAgent.create_agents(model, 5, [1, 2, 3, 4, 5])
+
+    subset = model.agents.select(lambda a: a.wealth > 2)
+
+    dataset = AgentDataSet(
+        "x",
+        model.agents,
+        agents=subset,
+        fields="wealth",
+    )
+
+    data = dataset.data
+    assert len(data) == len(subset)
+
+
+def test_agent_dataset_agents_override_with_class():
+    """Test agents override works with agent class source."""
+
+    class MyAgent(Agent):
+        def __init__(self, model, value):
+            super().__init__(model)
+            self.wealth = value
+
+    model = Model()
+    MyAgent.create_agents(model, 3, [1, 2, 3])
+
+    subset = model.agents
+
+    dataset = AgentDataSet(
+        "x",
+        MyAgent,
+        model=model,
+        agents=subset,
+        fields="wealth",
+    )
+
+    data = dataset.data
+    assert len(data) == len(subset)
+
+
+def test_agent_dataset_legacy_positional_fields():
+    """Test backward compatibility with positional fields argument."""
+
+    model = Model()
+
+    dataset = AgentDataSet("x", model.agents, "wealth")
+
+    assert dataset is not None
+
+
+def test_agent_dataset_dynamic_agents_with_class():
+    """Test dynamic agent addition is reflected in dataset."""
+
+    class MyAgent(Agent):
+        def __init__(self, model):
+            super().__init__(model)
+            self.wealth = 1
+
+    model = Model()
+
+    dataset = AgentDataSet(
+        "x",
+        MyAgent,
+        model=model,
+        fields="wealth",
+    )
+
+    assert len(dataset.data) == 0
+
+    MyAgent(model)
+    assert len(dataset.data) == 1
+
+    MyAgent(model)
+    assert len(dataset.data) == 2
+
+def test_agent_dataset_invalid_source_type():
+    """Test that invalid source type raises TypeError."""
+
+    with pytest.raises(TypeError):
+        AgentDataSet("invalid", 123, fields="wealth")


### PR DESCRIPTION
## Summary

This change allows AgentDataSet to accept an agent class. When a class is passed, agents are retrieved using model.agents_by_type. This brings it in line with how NumpyAgentDataSet works.

Fixes part of #3341 

## Motivation

AgentDataSet and NumpyAgentDataSet currently use different inputs (AgentSet vs agent class). This makes their APIs inconsistent and harder to use together. This change makes both datasets follow the same pattern.

## Implementation

- AgentDataSet now accepts either an AgentSet or an agent class
- When given a class, agents are taken from model.agents_by_type
- Existing behavior using AgentSet is unchanged
