### PR TITLE
Add agent-level action lifecycle hooks

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -299,3 +299,13 @@ class Agent[M: Model]:
     def is_busy(self) -> bool:
         """Whether the agent is currently performing an action."""
         return self.current_action is not None
+
+    # --- Action lifecycle hooks (override in subclasses) ---
+    def on_action_start(self, action: Action) -> None:
+        """Called after Action.on_start/on_resume. Override for agent-level responses."""
+
+    def on_action_complete(self, action: Action) -> None:
+        """Called after Action.on_complete. Override to decide the agent's next action."""
+
+    def on_action_interrupt(self, action: Action, progress: float) -> None:
+        """Called after Action.on_interrupt. Override to handle interruption at agent level."""

--- a/mesa/experimental/actions/actions.py
+++ b/mesa/experimental/actions/actions.py
@@ -263,6 +263,7 @@ class Action:
 
         # Schedule completion event for remaining duration
         self._event = self.model.schedule_event(self._do_complete, after=remaining)
+        self.agent.on_action_start(self)
         return self
 
     def interrupt(self) -> bool:
@@ -291,6 +292,7 @@ class Action:
             self.agent.current_action = None
 
         self.on_interrupt(self._progress)
+        self.agent.on_action_interrupt(self, self._progress)
         return True
 
     def cancel(self) -> bool:
@@ -315,6 +317,7 @@ class Action:
             self.agent.current_action = None
 
         self.on_interrupt(self._progress)
+        self.agent.on_action_interrupt(self, self._progress)
         return True
 
     # --- Internal ---
@@ -349,6 +352,7 @@ class Action:
             self.agent.current_action = None
 
         self.on_complete()
+        self.agent.on_action_complete(self)
 
     def __repr__(self) -> str:
         """Return string representation."""


### PR DESCRIPTION
### Summary
Adds three hooks to `Agent` that fire after the corresponding `Action` hooks, giving agents a centralized place for behavioral decision logic.

Quick prototype to see how https://github.com/mesa/mesa/discussions/3304#discussioncomment-16242923 would look. No tests etc. yet.

### Motive
Currently, every `Action.on_complete` and `Action.on_interrupt` must include "what next?" logic, leading to duplicated decision code across actions. This couples action _effects_ with agent-level behavioral _decisions_.

With agent-level hooks, actions stay single-purpose (defining their own effects), while the agent handles decisions in one place:

```python
class Forage(Action):
    def on_complete(self):
        self.agent.energy += 30  # Just the effect

class Sheep(Agent):
    def on_action_complete(self, action):
        if self.energy < 30:
            self.start_action(Rest(self))
        else:
            self.start_action(Forage(self))
```

### Implementation
**`agent.py`** — Three new no-op methods on `Agent`:
- `on_action_start(action)` — called after `Action.on_start`/`on_resume`
- `on_action_complete(action)` — called after `Action.on_complete`
- `on_action_interrupt(action, progress)` — called after `Action.on_interrupt`

**`actions.py`** — One line added in each of:
- `Action.start()` — calls `agent.on_action_start` (skipped for instantaneous actions, which go through `_do_complete` instead)
- `Action._do_complete()` — calls `agent.on_action_complete`
- `Action.interrupt()` and `Action.cancel()` — call `agent.on_action_interrupt`

### Usage Examples
**Before:** decision logic duplicated in every action:
```python
class Forage(Action):
    def on_complete(self):
        self.agent.energy += 30
        # decision logic here...
        if self.agent.sees_predator():
            self.agent.start_action(Flee(self.agent))
        elif self.agent.energy > 80:
            self.agent.start_action(Rest(self.agent))
        else:
            self.agent.start_action(Forage(self.agent))

class Rest(Action):
    def on_complete(self):
        self.agent.energy = min(100, self.agent.energy + 20)
        # ...duplicated here
        if self.agent.sees_predator():
            self.agent.start_action(Flee(self.agent))
        elif self.agent.energy > 80:
            self.agent.start_action(Rest(self.agent))
        else:
            self.agent.start_action(Forage(self.agent))

class Flee(Action):
    def on_complete(self):
        self.agent.move_away_from_predator()
        # ...and here
        if self.agent.sees_predator():
            self.agent.start_action(Flee(self.agent))
        elif self.agent.energy > 80:
            self.agent.start_action(Rest(self.agent))
        else:
            self.agent.start_action(Forage(self.agent))
```

**After:** actions are single-purpose, decisions live in one place:
```python
class Forage(Action):
    def on_complete(self):
        self.agent.energy += 30

class Rest(Action):
    def on_complete(self):
        self.agent.energy = min(100, self.agent.energy + 20)

class Flee(Action):
    def on_complete(self):
        self.agent.move_away_from_predator()

class Sheep(Agent):
    def on_action_complete(self, action):
        self.decide_next()

    def on_action_interrupt(self, action, progress):
        self.decide_next()

    def decide_next(self):
        if self.sees_predator():
            self.start_action(Flee(self))
        elif self.energy < 30:
            self.start_action(Rest(self))
        else:
            self.start_action(Forage(self))
```

Adding a fourth action (e.g. `Drink`) requires zero changes to decision logic. Changing the decision logic requires updating only one method.

All hooks default to `pass`, so existing code is unaffected.

### Additional Notes
- Hooks fire *after* the Action's own hooks, so `Action.on_complete` runs before `Agent.on_action_complete`.
- Zero-duration actions fire `on_action_complete` but not `on_action_start`, avoiding double-firing in the same instant.
- This is purely additive, you can still put all logic in `Action.on_complete` if you want.
- Ref: https://github.com/mesa/mesa/discussions/3304#discussioncomment-16242923