### PR TITLE
docs: clarify Action lifecycle and interrupt semantics in module docstring

### DIFF
--- a/mesa/experimental/actions/actions.py
+++ b/mesa/experimental/actions/actions.py
@@ -1,7 +1,7 @@
 """mesa.experimental.actions: Timed, interruptible actions for Mesa agents.
 
 An Action represents a discrete task an agent performs over a duration.
-It manages its own lifecycle (pending -> active -> completed/interrupted),
+It manages its own lifecycle (pending -> active -> completed/interrupted -> (only interrupted) active via start()/resume()),
 integrates with Mesa's event scheduler for precise timing, and supports
 interruption with progress tracking and optional resumption.
 
@@ -46,7 +46,7 @@ class ActionState(IntEnum):
 class Action:
     """An interruptible task an agent performs over time.
 
-    Actions progress through states (PENDING -> ACTIVE -> COMPLETED/INTERRUPTED),
+    Actions progress through states (PENDING -> ACTIVE -> COMPLETED/INTERRUPTED -> (only INTERRUPTED) ACTIVE via start()/resume()) and manage their own timing and progress,
     tracking elapsed time as a fraction from 0.0 to 1.0.
 
     Subclass and override on_start/on_resume/on_complete/on_interrupt for

--- a/mesa/experimental/actions/actions.py
+++ b/mesa/experimental/actions/actions.py
@@ -1,7 +1,7 @@
 """mesa.experimental.actions: Timed, interruptible actions for Mesa agents.
 
 An Action represents a discrete task an agent performs over a duration.
-It manages its own lifecycle (pending -> active -> completed/interrupted -> (only interrupted) active via start()/resume()),
+It manages its own lifecycle (pending -> active -> completed/interrupted -> (only interrupted) active via on_start()/on_resume()),
 integrates with Mesa's event scheduler for precise timing, and supports
 interruption with progress tracking and optional resumption.
 
@@ -46,7 +46,7 @@ class ActionState(IntEnum):
 class Action:
     """An interruptible task an agent performs over time.
 
-    Actions progress through states (PENDING -> ACTIVE -> COMPLETED/INTERRUPTED -> (only INTERRUPTED) ACTIVE via start()/resume()) and manage their own timing and progress,
+    Actions progress through states (PENDING -> ACTIVE -> COMPLETED/INTERRUPTED -> (only INTERRUPTED) ACTIVE via on_start()/on_resume()) and manage their own timing and progress,
     tracking elapsed time as a fraction from 0.0 to 1.0.
 
     Subclass and override on_start/on_resume/on_complete/on_interrupt for

--- a/mesa/experimental/actions/actions.py
+++ b/mesa/experimental/actions/actions.py
@@ -1,7 +1,8 @@
 """mesa.experimental.actions: Timed, interruptible actions for Mesa agents.
 
 An Action represents a discrete task an agent performs over a duration.
-It manages its own lifecycle (pending -> active -> completed/interrupted -> (only interrupted) active via on_start()/on_resume()),
+It progresses through states: PENDING → ACTIVE → COMPLETED or INTERRUPTED.
+Interrupted actions can resume by calling start(), which invokes on_resume(),
 integrates with Mesa's event scheduler for precise timing, and supports
 interruption with progress tracking and optional resumption.
 
@@ -46,8 +47,9 @@ class ActionState(IntEnum):
 class Action:
     """An interruptible task an agent performs over time.
 
-    Actions progress through states (PENDING -> ACTIVE -> COMPLETED/INTERRUPTED -> (only INTERRUPTED) ACTIVE via on_start()/on_resume()) and manage their own timing and progress,
-    tracking elapsed time as a fraction from 0.0 to 1.0.
+    Actions progress through states: PENDING → ACTIVE → COMPLETED or INTERRUPTED.
+    Interrupted actions can return to ACTIVE by calling start(), which invokes on_resume().
+    They manage their own timing and progress, tracking elapsed time as a fraction from 0.0 to 1.0.
 
     Subclass and override on_start/on_resume/on_complete/on_interrupt for
     custom behavior. on_resume() is called when a previously interrupted

--- a/mesa/experimental/actions/actions.py
+++ b/mesa/experimental/actions/actions.py
@@ -1,10 +1,11 @@
 """mesa.experimental.actions: Timed, interruptible actions for Mesa agents.
 
-An Action represents something an agent does over time. It integrates with
-Mesa's event scheduling system for precise timing and supports interruption
-with progress tracking and optional resumption.
+An Action represents a discrete task an agent performs over a duration. 
+It manages its own lifecycle (pending -> active -> completed/interrupted), 
+integrates with Mesa's event scheduler for precise timing, and supports 
+interruption with progress tracking and optional resumption.
 
-Actions are subclassable: override on_start(), on_complete(), and
+To use, subclass Action and override on_start(), on_complete(), and 
 on_interrupt() to define behavior.
 
 Example::
@@ -43,11 +44,12 @@ class ActionState(IntEnum):
 
 
 class Action:
-    """Something an agent does over time.
+    """An interruptible task with lifecycle tracking and priority-based preemption.
 
-    Actions have a duration, can be interrupted, and track their own
-    lifecycle state. They integrate with Mesa's event scheduler for
-    completion timing.
+    Actions progress through states (PENDING -> ACTIVE -> COMPLETED/INTERRUPTED),
+    tracking elapsed time as a fraction 0.0-1.0. Higher-priority actions can
+    interrupt lower-priority ones if allowed. Override on_start(), on_complete(),
+    and on_interrupt() to define behavior; all default to no-op.
 
     Subclass and override on_start/on_complete/on_interrupt for complex
     behavior. All hooks default to doing nothing (pass).

--- a/mesa/experimental/actions/actions.py
+++ b/mesa/experimental/actions/actions.py
@@ -5,8 +5,8 @@ It manages its own lifecycle (pending -> active -> completed/interrupted),
 integrates with Mesa's event scheduler for precise timing, and supports 
 interruption with progress tracking and optional resumption.
 
-To use, subclass Action and override on_start(), on_complete(), and 
-on_interrupt() to define behavior.
+To use, subclass Action and override on_start(), on_resume(),
+on_complete(), and on_interrupt() to define behavior.
 
 Example::
 
@@ -44,15 +44,17 @@ class ActionState(IntEnum):
 
 
 class Action:
-    """An interruptible task with lifecycle tracking and priority-based preemption.
+    """An interruptible task an agent performs over time.
 
     Actions progress through states (PENDING -> ACTIVE -> COMPLETED/INTERRUPTED),
-    tracking elapsed time as a fraction 0.0-1.0. Higher-priority actions can
-    interrupt lower-priority ones if allowed. Override on_start(), on_complete(),
-    and on_interrupt() to define behavior; all default to no-op.
+    tracking elapsed time as a fraction from 0.0 to 1.0.
 
-    Subclass and override on_start/on_complete/on_interrupt for complex
-    behavior. All hooks default to doing nothing (pass).
+    Subclass and override on_start/on_resume/on_complete/on_interrupt for
+    custom behavior. on_resume() is called when a previously interrupted
+    action starts again; by default it delegates to on_start().
+
+    This class does not enforce interruption ordering by priority.
+    The priority field is available for agent-level policies and custom logic.
 
     Attributes:
         agent: The agent performing this action.
@@ -60,9 +62,9 @@ class Action:
         name: Human-readable identifier. Defaults to the class name.
         duration: Time to complete. May be a callable(agent) -> float
             for state-dependent duration, resolved at start time.
-        priority: Importance level. Higher = more important. May be a
+        priority: Importance level associated with this action. May be a
             callable(agent) -> float, resolved at start time.
-        interruptible: Whether higher-priority actions can preempt this.
+        interruptible: Whether this action can be interrupted while active.
         state: Current lifecycle state (PENDING, ACTIVE, COMPLETED, INTERRUPTED).
         progress: Time fraction completed, 0.0 to 1.0. Computed live
             while the action is active.
@@ -90,7 +92,7 @@ class Action:
                 that receives the agent and returns a float. Resolved
                 when start() is called.
             name: Human-readable name. Defaults to the class name.
-            priority: Importance level for interruption decisions. Either
+            priority: Importance level associated with this action. Either
                 a float or a callable that receives the agent and returns
                 a float. Resolved when start() is called.
             interruptible: If False, interrupt() will fail and return False.

--- a/mesa/experimental/actions/actions.py
+++ b/mesa/experimental/actions/actions.py
@@ -2,9 +2,9 @@
 
 An Action represents a discrete task an agent performs over a duration.
 It progresses through states: PENDING → ACTIVE → COMPLETED or INTERRUPTED.
-Interrupted actions can resume by calling start(), which invokes on_resume(),
-integrates with Mesa's event scheduler for precise timing, and supports
-interruption with progress tracking and optional resumption.
+Interrupted actions can resume by calling start(), which invokes on_resume().
+The Action system integrates with Mesa's event scheduler for precise timing
+and supports interruption with progress tracking and optional resumption.
 
 To use, subclass Action and override on_start(), on_resume(),
 on_complete(), and on_interrupt() to define behavior.

--- a/mesa/experimental/actions/actions.py
+++ b/mesa/experimental/actions/actions.py
@@ -49,7 +49,7 @@ class Action:
 
     Actions progress through states: PENDING → ACTIVE → COMPLETED or INTERRUPTED.
     Interrupted actions can return to ACTIVE by calling start(), which invokes on_resume().
-    They manage their own timing and progress, tracking elapsed time as a fraction from 0.0 to 1.0.
+    They manage their own timing and progress, tracking progress as a fraction from 0.0 to 1.0.
 
     Subclass and override on_start/on_resume/on_complete/on_interrupt for
     custom behavior. on_resume() is called when a previously interrupted

--- a/mesa/experimental/actions/actions.py
+++ b/mesa/experimental/actions/actions.py
@@ -1,11 +1,11 @@
 """mesa.experimental.actions: Timed, interruptible actions for Mesa agents.
 
-An Action represents a discrete task an agent performs over a duration. 
-It manages its own lifecycle (pending -> active -> completed/interrupted), 
-integrates with Mesa's event scheduler for precise timing, and supports 
+An Action represents a discrete task an agent performs over a duration.
+It manages its own lifecycle (pending -> active -> completed/interrupted),
+integrates with Mesa's event scheduler for precise timing, and supports
 interruption with progress tracking and optional resumption.
 
-To use, subclass Action and override on_start(), on_complete(), and 
+To use, subclass Action and override on_start(), on_complete(), and
 on_interrupt() to define behavior.
 
 Example::


### PR DESCRIPTION
## Summary
- Clarifies the experimental Actions API documentation to distinguish state transitions from lifecycle hooks.
- Explicitly documents that Actions progress through states: PENDING → ACTIVE → COMPLETED or INTERRUPTED.
- Clarifies that interrupted actions resume by calling start(), which invokes on_resume()
- Improves onboarding by separating the lifecycle state machine from lifecycle hook behaviors.

## Changes
- Refined module-level docstring to explain Action state progression and resumption semantics.
- Updated class-level docstring to clearly separate state transitions (start() method) from lifecycle hooks (on_resume()).
- Removed misleading parenthetical descriptions that conflated method calls with hook names.
- Added explicit documentation that on_resume() is that correct hook for handling resumption (defaults to on_start()).

## Why
While building agent interaction models for a Mesa GSoC proposal, the initial Action documentation conflated state transitions with lifecycle hooks, making it unclear when to use start() vs. on_resume(). This update clarifies:

  - State transitions are performed by start(), interrupt(), cancel(), and the scheduler.
  - Lifecycle hooks (on_start(), on_resume(), on_complete(), on_interrupt()) are where users implement custom behavior.
  - Resumption specifically calls on_resume, not on_start().

## Validation
- [x] No breaking changes
- [ ] Documentation only (no logic changes)
- [ ] Example code runs as written

## Related
Connected to my Mesa learning-space models for GSoC agent interaction framework proposal:
- Market auction model (request-reply messaging patterns)
- Needs-driven wolf-sheep model (action-based behavior selection and interruption)
- Opinion diffusion model (signals and multi-agent communication)

See: https://github.com/SumeetDUTTA/GSoC-learning-space