### PR TITLE
Add join strategy hook for existing meta-agents

### DIFF
--- a/mesa/experimental/meta_agents/meta_agent.py
+++ b/mesa/experimental/meta_agents/meta_agent.py
@@ -256,7 +256,9 @@ def create_meta_agent(
 
     if len(existing_meta_agents) > 0:
         if len(existing_meta_agents) > 1 and select_existing_meta_agent is not None:
-            meta_agent = select_existing_meta_agent(existing_meta_agents, agents)
+            # Sort candidates by unique_id to ensure deterministic order
+            sorted_candidates = sorted(existing_meta_agents, key=lambda x: x.unique_id)
+            meta_agent = select_existing_meta_agent(sorted_candidates, agents)
             if meta_agent not in existing_meta_agents:
                 raise ValueError(
                     "select_existing_meta_agent must return one of the existing meta-agents."

--- a/mesa/experimental/meta_agents/meta_agent.py
+++ b/mesa/experimental/meta_agents/meta_agent.py
@@ -141,9 +141,9 @@ def create_meta_agent(
     mesa_agent_type: type[Agent] | None,
     meta_attributes: dict[str, Any] | None = None,
     meta_methods: dict[str, Callable] | None = None,
-    select_existing_meta_agent: Callable[[list[Any], list[Any]], Any] | None = None,
     assume_constituting_agent_methods: bool = False,
     assume_constituting_agent_attributes: bool = False,
+    select_existing_meta_agent: Callable[[list[Any], list[Any]], Any] | None = None,
 ) -> Any | None:
     """Create a new meta-agent class and instantiate agents.
 
@@ -153,14 +153,14 @@ def create_meta_agent(
     agents (Iterable[Any]): The agents to be included in the meta-agent.
     meta_attributes (Dict[str, Any]): Attributes to be added to the meta-agent.
     meta_methods (Dict[str, Callable]): Methods to be added to the meta-agent.
-    select_existing_meta_agent (Callable): Optional selector for choosing which
-        existing meta-agent to join when multiple of the same class exist. The
-        function receives the list of existing meta-agents and the candidate
-        agents list, and must return one of the existing meta-agents.
     assume_constituting_agent_methods (bool): Whether to assume methods from
     constituting_-agents as meta_agent methods.
     assume_constituting_agent_attributes (bool): Whether to retain attributes
     from constituting_-agents.
+    select_existing_meta_agent (Callable): Optional selector for choosing which
+        existing meta-agent to join when multiple of the same class exist. The
+        function receives the list of existing meta-agents and the candidate
+        agents list, and must return one of the existing meta-agents.
 
     Returns:
         - MetaAgent Instance
@@ -255,7 +255,7 @@ def create_meta_agent(
                     existing_meta_agents.append(ma)
 
     if len(existing_meta_agents) > 0:
-        if select_existing_meta_agent is not None:
+        if len(existing_meta_agents) > 1 and select_existing_meta_agent is not None:
             meta_agent = select_existing_meta_agent(existing_meta_agents, agents)
             if meta_agent not in existing_meta_agents:
                 raise ValueError(

--- a/mesa/experimental/meta_agents/meta_agent.py
+++ b/mesa/experimental/meta_agents/meta_agent.py
@@ -141,6 +141,7 @@ def create_meta_agent(
     mesa_agent_type: type[Agent] | None,
     meta_attributes: dict[str, Any] | None = None,
     meta_methods: dict[str, Callable] | None = None,
+    select_existing_meta_agent: Callable[[list[Any], list[Any]], Any] | None = None,
     assume_constituting_agent_methods: bool = False,
     assume_constituting_agent_attributes: bool = False,
 ) -> Any | None:
@@ -152,6 +153,10 @@ def create_meta_agent(
     agents (Iterable[Any]): The agents to be included in the meta-agent.
     meta_attributes (Dict[str, Any]): Attributes to be added to the meta-agent.
     meta_methods (Dict[str, Callable]): Methods to be added to the meta-agent.
+    select_existing_meta_agent (Callable): Optional selector for choosing which
+        existing meta-agent to join when multiple of the same class exist. The
+        function receives the list of existing meta-agents and the candidate
+        agents list, and must return one of the existing meta-agents.
     assume_constituting_agent_methods (bool): Whether to assume methods from
     constituting_-agents as meta_agent methods.
     assume_constituting_agent_attributes (bool): Whether to retain attributes
@@ -250,13 +255,18 @@ def create_meta_agent(
                     existing_meta_agents.append(ma)
 
     if len(existing_meta_agents) > 0:
-        # TODO: Add way for user to specify how agents join meta-agent
-        # instead of random choice if there are multiple meta-agents of the same class
-        meta_agent = (
-            sorted(existing_meta_agents, key=lambda x: x.unique_id)[0]
-            if len(existing_meta_agents) > 1
-            else existing_meta_agents[0]
-        )
+        if select_existing_meta_agent is not None:
+            meta_agent = select_existing_meta_agent(existing_meta_agents, agents)
+            if meta_agent not in existing_meta_agents:
+                raise ValueError(
+                    "select_existing_meta_agent must return one of the existing meta-agents."
+                )
+        else:
+            meta_agent = (
+                sorted(existing_meta_agents, key=lambda x: x.unique_id)[0]
+                if len(existing_meta_agents) > 1
+                else existing_meta_agents[0]
+            )
         add_attributes(meta_agent, agents, meta_attributes)
         add_methods(meta_agent, agents, meta_methods)
         meta_agent.add_constituting_agents(agents)

--- a/tests/examples/test_examples_viz.py
+++ b/tests/examples/test_examples_viz.py
@@ -215,13 +215,7 @@ def test_virus_on_network_model(solara_test, page_session: playwright.sync_api.P
     """Test virus on network model behavior and visualization."""
     from mesa.examples.basic.virus_on_network.model import State  # noqa: PLC0415
 
-    model = VirusOnNetwork(
-        rng=42,
-        virus_spread_chance=1.0,
-        virus_check_frequency=1.0,
-        recovery_chance=1.0,
-        gain_resistance_chance=1.0,
-    )
+    model = VirusOnNetwork(rng=42)
 
     def agent_portrayal(agent):
         node_color_dict = {

--- a/tests/examples/test_examples_viz.py
+++ b/tests/examples/test_examples_viz.py
@@ -215,7 +215,13 @@ def test_virus_on_network_model(solara_test, page_session: playwright.sync_api.P
     """Test virus on network model behavior and visualization."""
     from mesa.examples.basic.virus_on_network.model import State  # noqa: PLC0415
 
-    model = VirusOnNetwork(rng=42)
+    model = VirusOnNetwork(
+        rng=42,
+        virus_spread_chance=1.0,
+        virus_check_frequency=1.0,
+        recovery_chance=1.0,
+        gain_resistance_chance=1.0,
+    )
 
     def agent_portrayal(agent):
         node_color_dict = {

--- a/tests/experimental/test_meta_agents.py
+++ b/tests/experimental/test_meta_agents.py
@@ -191,7 +191,7 @@ def test_create_meta_agent_custom_join_strategy_requires_existing(setup_agents):
 
     with pytest.raises(
         ValueError,
-        match="select_existing_meta_agent must return one of the existing meta-agents.",
+        match=r"select_existing_meta_agent must return one of the existing meta-agents\.",
     ):
         create_meta_agent(
             model,

--- a/tests/experimental/test_meta_agents.py
+++ b/tests/experimental/test_meta_agents.py
@@ -142,7 +142,7 @@ def test_create_meta_agent_custom_join_strategy(setup_agents):
     """Test selecting an existing meta-agent with a custom join strategy."""
     model, agents = setup_agents
 
-    meta_agent1 = create_meta_agent(
+    _meta_agent1 = create_meta_agent(
         model,
         "MetaAgentClass",
         [agents[0]],
@@ -167,6 +167,40 @@ def test_create_meta_agent_custom_join_strategy(setup_agents):
     )
 
     assert meta_agent3 is meta_agent2
+
+
+def test_create_meta_agent_custom_join_strategy_requires_existing(setup_agents):
+    """Test selector validation rejects non-existing meta-agents."""
+    model, agents = setup_agents
+
+    meta_agent1 = create_meta_agent(
+        model,
+        "MetaAgentClass",
+        [agents[0]],
+        Agent,
+    )
+    create_meta_agent(
+        model,
+        "MetaAgentClass",
+        [agents[1]],
+        Agent,
+    )
+
+    def pick_non_existing(_existing_meta_agents, _agents):
+        return MetaAgent(model, set())
+
+    with pytest.raises(
+        ValueError, match="select_existing_meta_agent must return one of the existing meta-agents."
+    ):
+        create_meta_agent(
+            model,
+            "MetaAgentClass",
+            [agents[0], agents[1]],
+            Agent,
+            select_existing_meta_agent=pick_non_existing,
+        )
+
+    assert meta_agent1 in model.agents
 
 
 def test_meta_agent_integration(setup_agents):

--- a/tests/experimental/test_meta_agents.py
+++ b/tests/experimental/test_meta_agents.py
@@ -418,3 +418,41 @@ def test_find_combinations_without_evaluation_func(setup_agents):
     # This should not cause a TypeError from unpacking
     result = find_combinations(model, model.agents, size=2, evaluation_func=None)
     assert result == []  # No combinations when no evaluation function
+
+
+def test_create_meta_agent_default_join_strategy(setup_agents):
+    """Test default behavior selects lowest unique_id when no selector is provided.
+
+    Regression test for backward compatibility: when multiple existing meta-agents
+    of the same class exist and no select_existing_meta_agent is provided,
+    create_meta_agent should join the one with the lowest unique_id.
+    """
+    model, agents = setup_agents
+
+    meta_agent1 = create_meta_agent(
+        model,
+        "MetaAgentClass",
+        [agents[0]],
+        Agent,
+    )
+    meta_agent2 = create_meta_agent(
+        model,
+        "MetaAgentClass",
+        [agents[1]],
+        Agent,
+    )
+
+    # Ensure meta_agent1 has lower unique_id
+    assert meta_agent1.unique_id < meta_agent2.unique_id
+
+    # When no selector is provided, should join the one with lowest unique_id
+    meta_agent3 = create_meta_agent(
+        model,
+        "MetaAgentClass",
+        [agents[0], agents[1]],
+        Agent,
+    )
+
+    assert meta_agent3 is meta_agent1
+    assert agents[0] in meta_agent1.agents
+    assert agents[1] in meta_agent1.agents

--- a/tests/experimental/test_meta_agents.py
+++ b/tests/experimental/test_meta_agents.py
@@ -190,7 +190,8 @@ def test_create_meta_agent_custom_join_strategy_requires_existing(setup_agents):
         return MetaAgent(model, set())
 
     with pytest.raises(
-        ValueError, match="select_existing_meta_agent must return one of the existing meta-agents."
+        ValueError,
+        match="select_existing_meta_agent must return one of the existing meta-agents.",
     ):
         create_meta_agent(
             model,

--- a/tests/experimental/test_meta_agents.py
+++ b/tests/experimental/test_meta_agents.py
@@ -186,8 +186,10 @@ def test_create_meta_agent_custom_join_strategy_requires_existing(setup_agents):
         Agent,
     )
 
+    sentinel = object()
+
     def pick_non_existing(_existing_meta_agents, _agents):
-        return MetaAgent(model, set())
+        return sentinel
 
     with pytest.raises(
         ValueError,

--- a/tests/experimental/test_meta_agents.py
+++ b/tests/experimental/test_meta_agents.py
@@ -138,6 +138,37 @@ def test_add_agents_to_existing_meta_agent(setup_agents):
     assert meta_agent1.custom_method() == "custom_method_value"
 
 
+def test_create_meta_agent_custom_join_strategy(setup_agents):
+    """Test selecting an existing meta-agent with a custom join strategy."""
+    model, agents = setup_agents
+
+    meta_agent1 = create_meta_agent(
+        model,
+        "MetaAgentClass",
+        [agents[0]],
+        Agent,
+    )
+    meta_agent2 = create_meta_agent(
+        model,
+        "MetaAgentClass",
+        [agents[1]],
+        Agent,
+    )
+
+    def pick_highest_unique_id(existing_meta_agents, _agents):
+        return max(existing_meta_agents, key=lambda ma: ma.unique_id)
+
+    meta_agent3 = create_meta_agent(
+        model,
+        "MetaAgentClass",
+        [agents[0], agents[1]],
+        Agent,
+        select_existing_meta_agent=pick_highest_unique_id,
+    )
+
+    assert meta_agent3 is meta_agent2
+
+
 def test_meta_agent_integration(setup_agents):
     """Test the integration of MetaAgent with the model.
 


### PR DESCRIPTION
## Summary
- add an optional join-strategy hook when multiple existing meta-agents of the same class are available
- keep default behavior unchanged when no selector is provided
- add a regression test to validate custom selection logic

## Why
There is a TODO in `create_meta_agent` about allowing user control over how agents join an existing meta-agent. This adds a minimal, opt-in selector without changing current defaults.

## Scope
- Atomic change: meta-agent selection only
- Files changed: 2

## Validation
- `python -m pytest tests/experimental/test_meta_agents.py -q`

## Overlap check
- No existing open PR found for this specific join-strategy hook.
