### PR TITLE
feat: add joining_func to create_meta_agent (fixes #3632)

### DIFF
--- a/mesa/experimental/meta_agents/meta_agent.py
+++ b/mesa/experimental/meta_agents/meta_agent.py
@@ -143,9 +143,8 @@ def create_meta_agent(
     meta_methods: dict[str, Callable] | None = None,
     assume_constituting_agent_methods: bool = False,
     assume_constituting_agent_attributes: bool = False,
-    joining_func: Callable[
-        [list[Agent], list["MetaAgent"], Any], "MetaAgent"
-    ] | None = None,  
+    joining_func: Callable[[list[Agent], list["MetaAgent"], Any], "MetaAgent"]
+    | None = None,
 ) -> Any | None:
     """Create a new meta-agent class and instantiate agents.
 

--- a/mesa/experimental/meta_agents/meta_agent.py
+++ b/mesa/experimental/meta_agents/meta_agent.py
@@ -143,6 +143,9 @@ def create_meta_agent(
     meta_methods: dict[str, Callable] | None = None,
     assume_constituting_agent_methods: bool = False,
     assume_constituting_agent_attributes: bool = False,
+    joining_func: Callable[
+        [list[Agent], list["MetaAgent"], Any], "MetaAgent"
+    ] | None = None,  
 ) -> Any | None:
     """Create a new meta-agent class and instantiate agents.
 
@@ -156,6 +159,11 @@ def create_meta_agent(
     constituting_-agents as meta_agent methods.
     assume_constituting_agent_attributes (bool): Whether to retain attributes
     from constituting_-agents.
+    joining_func (Callable | None): Optional function to select which existing
+    meta-agent agents should join when multiple candidates of the same class
+    exist. Signature: ``joining_func(candidate_agents, existing_meta_agents,
+    model) -> MetaAgent``. If None, the meta-agent with the lowest unique_id
+    is chosen (original behaviour).
 
     Returns:
         - MetaAgent Instance
@@ -238,7 +246,6 @@ def create_meta_agent(
                 setattr(meta_agent_instance, key, value)
 
     # Path 1 - Add agents to existing meta-agent of the SAME CLASS if any exist
-    # This preserves the "singleton/unique group per class" behavior while allowing overlap between different classes
     existing_meta_agents = []
     for a in agents:
         if hasattr(a, "meta_agents"):
@@ -250,13 +257,13 @@ def create_meta_agent(
                     existing_meta_agents.append(ma)
 
     if len(existing_meta_agents) > 0:
-        # TODO: Add way for user to specify how agents join meta-agent
-        # instead of random choice if there are multiple meta-agents of the same class
-        meta_agent = (
-            sorted(existing_meta_agents, key=lambda x: x.unique_id)[0]
-            if len(existing_meta_agents) > 1
-            else existing_meta_agents[0]
-        )
+        if len(existing_meta_agents) > 1:
+            if joining_func is not None:
+                meta_agent = joining_func(agents, existing_meta_agents, model)
+            else:
+                meta_agent = sorted(existing_meta_agents, key=lambda x: x.unique_id)[0]
+        else:
+            meta_agent = existing_meta_agents[0]
         add_attributes(meta_agent, agents, meta_attributes)
         add_methods(meta_agent, agents, meta_methods)
         meta_agent.add_constituting_agents(agents)
@@ -275,7 +282,7 @@ def create_meta_agent(
             # Path 3 - Create a new meta-agent class
             meta_agent_class = type(
                 new_agent_class,
-                (MetaAgent, *mesa_agent_type),  # Inherit Mesa Agent Classes
+                (MetaAgent, *mesa_agent_type),
                 {
                     "unique_id": None,
                     "_constituting_set": None,

--- a/tests/experimental/test_meta_agents.py
+++ b/tests/experimental/test_meta_agents.py
@@ -400,13 +400,16 @@ def test_meta_agent_remove_with_multiple_memberships():
     assert a2.meta_agent is None
     assert len(a2.meta_agents) == 0
 
+
 def test_joining_func_default_picks_lowest_unique_id(setup_agents):
     """Without joining_func, lowest unique_id meta-agent is chosen (backward compat)."""
     model, agents = setup_agents
     a, b, c, d = agents
 
     ma1 = create_meta_agent(model, "Team", [a, b], Agent)
-    ma2_class = type("Team", (MetaAgent, Agent), {"unique_id": None, "_constituting_set": None})
+    ma2_class = type(
+        "Team", (MetaAgent, Agent), {"unique_id": None, "_constituting_set": None}
+    )
     ma2 = ma2_class(model, [c])
 
     # Give d membership in both to force multi-candidate path
@@ -425,7 +428,9 @@ def test_joining_func_return_value_is_respected(setup_agents):
     a, b, c, d = agents
 
     ma1 = create_meta_agent(model, "Crew", [a, b], Agent)
-    ma2_class = type("Crew", (MetaAgent, Agent), {"unique_id": None, "_constituting_set": None})
+    ma2_class = type(
+        "Crew", (MetaAgent, Agent), {"unique_id": None, "_constituting_set": None}
+    )
     ma2 = ma2_class(model, [c])
 
     d.meta_agents = {ma1, ma2}
@@ -433,7 +438,10 @@ def test_joining_func_return_value_is_respected(setup_agents):
     ma2._constituting_set.add(d)
 
     chosen = create_meta_agent(
-        model, "Crew", [d], Agent,
+        model,
+        "Crew",
+        [d],
+        Agent,
         joining_func=lambda agents, metas, m: ma2,
     )
     assert chosen is ma2
@@ -461,7 +469,9 @@ def test_joining_func_join_largest_strategy(setup_agents):
     a, b, c, d = agents
 
     small = create_meta_agent(model, "Brigade", [a], Agent)
-    large_class = type("Brigade", (MetaAgent, Agent), {"unique_id": None, "_constituting_set": None})
+    large_class = type(
+        "Brigade", (MetaAgent, Agent), {"unique_id": None, "_constituting_set": None}
+    )
     large = large_class(model, [b, c, d])
 
     # Give a membership in both

--- a/tests/experimental/test_meta_agents.py
+++ b/tests/experimental/test_meta_agents.py
@@ -399,3 +399,78 @@ def test_meta_agent_remove_with_multiple_memberships():
     # a2 was only in ma1, should be fully cleaned
     assert a2.meta_agent is None
     assert len(a2.meta_agents) == 0
+
+def test_joining_func_default_picks_lowest_unique_id(setup_agents):
+    """Without joining_func, lowest unique_id meta-agent is chosen (backward compat)."""
+    model, agents = setup_agents
+    a, b, c, d = agents
+
+    ma1 = create_meta_agent(model, "Team", [a, b], Agent)
+    ma2_class = type("Team", (MetaAgent, Agent), {"unique_id": None, "_constituting_set": None})
+    ma2 = ma2_class(model, [c])
+
+    # Give d membership in both to force multi-candidate path
+    d.meta_agents = {ma1, ma2}
+    ma1._constituting_set.add(d)
+    ma2._constituting_set.add(d)
+
+    result = create_meta_agent(model, "Team", [d], Agent)
+    lowest = sorted([ma1, ma2], key=lambda x: x.unique_id)[0]
+    assert result is lowest
+
+
+def test_joining_func_return_value_is_respected(setup_agents):
+    """The meta-agent returned by joining_func is the one agents join."""
+    model, agents = setup_agents
+    a, b, c, d = agents
+
+    ma1 = create_meta_agent(model, "Crew", [a, b], Agent)
+    ma2_class = type("Crew", (MetaAgent, Agent), {"unique_id": None, "_constituting_set": None})
+    ma2 = ma2_class(model, [c])
+
+    d.meta_agents = {ma1, ma2}
+    ma1._constituting_set.add(d)
+    ma2._constituting_set.add(d)
+
+    chosen = create_meta_agent(
+        model, "Crew", [d], Agent,
+        joining_func=lambda agents, metas, m: ma2,
+    )
+    assert chosen is ma2
+
+
+def test_joining_func_not_called_for_single_candidate(setup_agents):
+    """joining_func must not be called when only one candidate meta-agent exists."""
+    model, agents = setup_agents
+    a, b, c = agents[0], agents[1], agents[2]
+
+    create_meta_agent(model, "Unit", [a, b], Agent)
+    call_count = {"n": 0}
+
+    def should_not_be_called(candidate_agents, existing_meta_agents, mdl):
+        call_count["n"] += 1
+        return existing_meta_agents[0]
+
+    create_meta_agent(model, "Unit", [a], Agent, joining_func=should_not_be_called)
+    assert call_count["n"] == 0
+
+
+def test_joining_func_join_largest_strategy(setup_agents):
+    """Domain strategy: joining_func can select the largest existing meta-agent."""
+    model, agents = setup_agents
+    a, b, c, d = agents
+
+    small = create_meta_agent(model, "Brigade", [a], Agent)
+    large_class = type("Brigade", (MetaAgent, Agent), {"unique_id": None, "_constituting_set": None})
+    large = large_class(model, [b, c, d])
+
+    # Give a membership in both
+    a.meta_agents = {small, large}
+    small._constituting_set.add(a)
+    large._constituting_set.add(a)
+
+    def join_largest(candidate_agents, existing_meta_agents, model):
+        return max(existing_meta_agents, key=lambda ma: len(ma))
+
+    chosen = create_meta_agent(model, "Brigade", [a], Agent, joining_func=join_largest)
+    assert chosen is large


### PR DESCRIPTION
## Summary
This PR adds support for a user-defined `joining_func` in `create_meta_agent`, allowing custom logic for selecting which meta-agent an agent joins when multiple candidates exist.

## Problem
Currently, when multiple meta-agents of the same class exist, the selection defaults to the one with the lowest `unique_id`. This behavior is hardcoded and does not allow user customization.

## Solution
- Introduced an optional `joining_func` parameter
- If provided, it determines which meta-agent to join
- If not provided, retains existing behavior (lowest `unique_id`)
- Ensures full backward compatibility

## Changes
- Updated function signature in `meta_agent.py`
- Replaced TODO logic with conditional selection
- Added comprehensive test cases for:
  - Default behavior
  - Custom selection logic
  - Edge cases (single candidate)
  - Strategy-based selection

## Tests
All new tests pass and existing functionality remains unaffected.

## Related Issue
Fixes #3632
