### PR TITLE
test: stabilize action interruption and viz tests

### DIFF
--- a/tests/examples/test_examples_viz.py
+++ b/tests/examples/test_examples_viz.py
@@ -28,6 +28,25 @@ from mesa.visualization.components.matplotlib_components import (
 )
 
 
+def take_stable_screenshot(
+    locator: playwright.sync_api.Locator, retries: int = 3
+) -> bytes:
+    """Retry element screenshots when the DOM swaps the target node."""
+    last_error = None
+
+    for _ in range(retries):
+        locator.wait_for(state="visible")
+        try:
+            return locator.screenshot()
+        except playwright.sync_api.Error as error:
+            if "Element is not attached to the DOM" not in str(error):
+                raise
+            last_error = error
+
+    assert last_error is not None
+    raise last_error
+
+
 def run_model_test(
     model,
     agent_portrayal,
@@ -54,12 +73,12 @@ def run_model_test(
         # Display and capture the initial visualizations
         display(space_viz)
         page_session.wait_for_selector("img")  # buffer for rendering
-        initial_space = page_session.locator("img").screenshot()
+        initial_space = take_stable_screenshot(page_session.locator("img"))
 
         if measure_config:
             display(graph_viz)
             page_session.wait_for_selector("img")
-            initial_graph = page_session.locator("img").screenshot()
+            initial_graph = take_stable_screenshot(page_session.locator("img"))
 
         # Run the model for specified number of steps
         model.run_for(steps)
@@ -76,12 +95,12 @@ def run_model_test(
         # Display and capture the updated visualizations
         display(space_viz)
         page_session.wait_for_selector("img")
-        changed_space = page_session.locator("img").first.screenshot()
+        changed_space = take_stable_screenshot(page_session.locator("img").first)
 
         if measure_config:
             display(graph_viz)
             page_session.wait_for_selector("img")
-            changed_graph = page_session.locator("img").last.screenshot()
+            changed_graph = take_stable_screenshot(page_session.locator("img").last)
 
         # Convert screenshots to base64 for comparison
         initial_space_encoding = base64.b64encode(initial_space).decode()

--- a/tests/experimental/test_actions_interruption.py
+++ b/tests/experimental/test_actions_interruption.py
@@ -1,0 +1,336 @@
+"""Tests for mesa.experimental.actions interruption and resumption behavior.
+
+Provides comprehensive coverage for action lifecycle transitions, interrupt
+callbacks, progress tracking, and resumable actions—critical for agent
+interaction patterns that depend on interruptible task scheduling.
+"""
+
+# ruff: noqa: D102, D107
+import pytest
+
+from mesa import Agent, Model
+from mesa.experimental.actions import Action, ActionState
+
+
+class TrackedAction(Action):
+    """Action subclass that tracks lifecycle events for testing."""
+
+    def __init__(self, agent, duration=5.0, **kwargs):
+        super().__init__(agent, duration=duration, **kwargs)
+        self.on_start_called = 0
+        self.on_resume_called = 0
+        self.on_complete_called = 0
+        self.on_interrupt_called = 0
+        self.interrupt_progress = None
+
+    def on_start(self):
+        self.on_start_called += 1
+
+    def on_resume(self):
+        self.on_resume_called += 1
+        super().on_resume()
+
+    def on_complete(self):
+        self.on_complete_called += 1
+
+    def on_interrupt(self, progress):
+        self.on_interrupt_called += 1
+        self.interrupt_progress = progress
+
+
+def make_model_and_agent():
+    """Factory for creating a test model and agent."""
+    model = Model()
+    agent = Agent(model)
+    return model, agent
+
+
+class TestActionInterruption:
+    """Tests for action interruption behavior."""
+
+    def test_interrupt_active_action_returns_true(self):
+        """Interrupting an active action should return True."""
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+        action.start()
+
+        assert action.state is ActionState.ACTIVE
+        success = action.interrupt()
+
+        assert success is True
+        assert action.state is ActionState.INTERRUPTED
+
+    def test_interrupt_inactive_action_returns_false(self):
+        """Interrupting a non-active action should return False."""
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+
+        assert action.state is ActionState.PENDING
+        success = action.interrupt()
+
+        assert success is False
+        assert action.state is ActionState.PENDING
+
+    def test_interrupt_calls_on_interrupt_callback(self):
+        """Interrupting an action should call on_interrupt with progress."""
+        model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+        action.start()
+
+        # Manually set progress to simulate partial completion
+        action._progress = 0.5
+        action._event = None  # Cancel the scheduled event
+
+        action.interrupt()
+
+        assert action.on_interrupt_called == 1
+        assert action.interrupt_progress == pytest.approx(0.5, abs=0.01)
+
+    def test_interrupt_non_interruptible_action_returns_false(self):
+        """Interrupting a non-interruptible action should fail."""
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0, interruptible=False)
+        action.start()
+
+        assert action.interruptible is False
+        success = action.interrupt()
+
+        assert success is False
+        assert action.state is ActionState.ACTIVE
+
+    def test_interrupt_clears_agent_reference(self):
+        """Interrupting an action should clear agent.current_action."""
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+        action.start()
+        agent.current_action = action
+
+        action.interrupt()
+
+        assert agent.current_action is None
+
+    def test_interrupt_cancels_scheduled_event(self):
+        """Interrupting should cancel the scheduled completion event."""
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+        action.start()
+
+        assert action._event is not None
+        action.interrupt()
+
+        assert action._event is None
+
+
+class TestActionResumption:
+    """Tests for resuming interrupted actions."""
+
+    def test_resumable_action_after_interrupt(self):
+        """A recently interrupted action should be resumable."""
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+        action.start()
+        action.interrupt()
+
+        assert action.state is ActionState.INTERRUPTED
+        assert action.is_resumable is True
+
+    def test_non_resumable_action_when_completed(self):
+        """A completed action should not be resumable."""
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+        action.start()
+        action._do_complete()
+
+        assert action.state is ActionState.COMPLETED
+        assert action.is_resumable is False
+
+    def test_resume_calls_on_resume_not_on_start(self):
+        """Resuming an action should call on_resume."""
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+        action.start()
+
+        assert action.on_start_called == 1
+        assert action.on_resume_called == 0
+
+        action.interrupt()
+        action.start()  # Resume
+
+        # on_resume is called when resuming (default on_resume calls on_start)
+        assert action.on_resume_called == 1  # Called on resume
+
+    def test_resume_preserves_progress(self):
+        """Resuming should preserve progress from before interruption."""
+        model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+        action.start()
+
+        # Simulate 30% completion
+        action._progress = 0.3
+        action._event = None
+
+        action.interrupt()
+
+        assert abs(action.progress - 0.3) < 0.01
+
+        action.start()  # Resume
+
+        assert abs(action.progress - 0.3) < 0.01
+
+    def test_resume_invalid_state_raises_error(self):
+        """Resuming an action not in PENDING or INTERRUPTED state should raise."""
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+        action.start()
+        action._do_complete()
+
+        # Action is now COMPLETED, not resumable
+        with pytest.raises(ValueError, match="Cannot start action in COMPLETED state"):
+            action.start()
+
+
+class TestActionCancel:
+    """Tests for action cancellation (forced interrupt)."""
+
+    def test_cancel_non_interruptible_action_succeeds(self):
+        """Canceling should work even on non-interruptible actions."""
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0, interruptible=False)
+        action.start()
+
+        assert action.interruptible is False
+        success = action.cancel()
+
+        assert success is True
+        assert action.state is ActionState.INTERRUPTED
+
+    def test_cancel_calls_on_interrupt(self):
+        """Canceling should call on_interrupt with progress."""
+        model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+        action.start()
+
+        action._progress = 0.7
+        action._event = None
+
+        action.cancel()
+
+        assert action.on_interrupt_called == 1
+        assert abs(action.interrupt_progress - 0.7) < 0.01
+
+    def test_cancel_inactive_action_returns_false(self):
+        """Canceling a non-active action should return False."""
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+
+        success = action.cancel()
+
+        assert success is False
+        assert action.state is ActionState.PENDING
+
+
+class TestActionProgressTracking:
+    """Tests for progress tracking during action execution."""
+
+    def test_progress_starts_at_zero(self):
+        """A new action should have progress 0.0."""
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+
+        assert action.progress == 0.0
+
+    def test_progress_frozen_on_interrupt(self):
+        """Interrupting should freeze progress at that moment."""
+        model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+        action.start()
+
+        # Simulate 40% elapsed
+        action._progress = 0.4
+        action._event = None
+
+        action.interrupt()
+
+        # Progress should stay at 0.4
+        assert abs(action.progress - 0.4) < 0.01
+
+    def test_remaining_time_computed_live(self):
+        """Remaining time should be computed based on duration and progress."""
+        model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+        action.start()
+
+        action._progress = 0.25
+        action._event = None
+
+        # 10 * (1 - 0.25) = 7.5
+        assert abs(action.remaining_time - 7.5) < 0.01
+
+    def test_elapsed_time_computed_correctly(self):
+        """Elapsed time should be progress * duration."""
+        model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=20.0)
+        action.start()
+
+        action._progress = 0.6
+        action._event = None
+
+        # 20 * 0.6 = 12.0
+        assert abs(action.elapsed_time - 12.0) < 0.01
+
+
+class TestActionEdgeCases:
+    """Tests for edge cases and boundary conditions."""
+
+    def test_instantaneous_action_completes_immediately(self):
+        """An action with duration 0 should complete immediately."""
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=0.0)
+        action.start()
+
+        assert action.state is ActionState.COMPLETED
+        assert action.on_complete_called == 1
+
+    def test_action_with_callable_duration(self):
+        """Actions should support dynamic duration via callable."""
+        _model, agent = make_model_and_agent()
+
+        def get_duration(agent):
+            return 15.0
+
+        action = TrackedAction(agent, duration=get_duration)
+        action.start()
+
+        assert action.duration == 15.0
+
+    def test_action_with_callable_priority(self):
+        """Actions should support dynamic priority via callable."""
+        _model, agent = make_model_and_agent()
+
+        def get_priority(agent):
+            return 3.0
+
+        action = TrackedAction(agent, priority=get_priority)
+        action.start()
+
+        assert action.priority == 3.0
+
+    def test_negative_duration_raises_error(self):
+        """Creating an action with negative duration should raise."""
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=-5.0)
+
+        with pytest.raises(ValueError, match="Action duration must be >= 0"):
+            action.start()
+
+    def test_repr_format(self):
+        """Action.__repr__ should include state, progress, and duration."""
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, duration=10.0)
+        action.start()
+
+        repr_str = repr(action)
+
+        assert "TrackedAction" in repr_str
+        assert "ACTIVE" in repr_str
+        assert "duration=10.0" in repr_str

--- a/tests/experimental/test_actions_interruption.py
+++ b/tests/experimental/test_actions_interruption.py
@@ -123,6 +123,8 @@ class TestActionInterruption:
 
         assert action.state is ActionState.INTERRUPTED
         assert action.on_complete_called == 0
+
+
 class TestActionResumption:
     """Tests for resuming interrupted actions."""
 

--- a/tests/experimental/test_actions_interruption.py
+++ b/tests/experimental/test_actions_interruption.py
@@ -73,7 +73,7 @@ class TestActionInterruption:
 
     def test_interrupt_calls_on_interrupt_callback(self):
         """Interrupting an action should call on_interrupt with progress."""
-        model, agent = make_model_and_agent()
+        _model, agent = make_model_and_agent()
         action = TrackedAction(agent, duration=10.0)
         action.start()
 
@@ -161,7 +161,7 @@ class TestActionResumption:
 
     def test_resume_preserves_progress(self):
         """Resuming should preserve progress from before interruption."""
-        model, agent = make_model_and_agent()
+        _model, agent = make_model_and_agent()
         action = TrackedAction(agent, duration=10.0)
         action.start()
 
@@ -206,7 +206,7 @@ class TestActionCancel:
 
     def test_cancel_calls_on_interrupt(self):
         """Canceling should call on_interrupt with progress."""
-        model, agent = make_model_and_agent()
+        _model, agent = make_model_and_agent()
         action = TrackedAction(agent, duration=10.0)
         action.start()
 
@@ -241,7 +241,7 @@ class TestActionProgressTracking:
 
     def test_progress_frozen_on_interrupt(self):
         """Interrupting should freeze progress at that moment."""
-        model, agent = make_model_and_agent()
+        _model, agent = make_model_and_agent()
         action = TrackedAction(agent, duration=10.0)
         action.start()
 
@@ -256,7 +256,7 @@ class TestActionProgressTracking:
 
     def test_remaining_time_computed_live(self):
         """Remaining time should be computed based on duration and progress."""
-        model, agent = make_model_and_agent()
+        _model, agent = make_model_and_agent()
         action = TrackedAction(agent, duration=10.0)
         action.start()
 
@@ -268,7 +268,7 @@ class TestActionProgressTracking:
 
     def test_elapsed_time_computed_correctly(self):
         """Elapsed time should be progress * duration."""
-        model, agent = make_model_and_agent()
+        _model, agent = make_model_and_agent()
         action = TrackedAction(agent, duration=20.0)
         action.start()
 

--- a/tests/experimental/test_actions_interruption.py
+++ b/tests/experimental/test_actions_interruption.py
@@ -110,16 +110,19 @@ class TestActionInterruption:
 
     def test_interrupt_cancels_scheduled_event(self):
         """Interrupting should cancel the scheduled completion event."""
-        _model, agent = make_model_and_agent()
+        model, agent = make_model_and_agent()
         action = TrackedAction(agent, duration=10.0)
         action.start()
 
-        assert action._event is not None
+        # Interrupt before original completion time.
         action.interrupt()
 
-        assert action._event is None
+        # Advance time well past the original completion point; the action
+        # should remain interrupted and never complete.
+        model.run_for(20.0)
 
-
+        assert action.state is ActionState.INTERRUPTED
+        assert action.on_complete_called == 0
 class TestActionResumption:
     """Tests for resuming interrupted actions."""
 

--- a/tests/experimental/test_actions_interruption.py
+++ b/tests/experimental/test_actions_interruption.py
@@ -161,13 +161,12 @@ class TestActionResumption:
 
     def test_resume_preserves_progress(self):
         """Resuming should preserve progress from before interruption."""
-        _model, agent = make_model_and_agent()
+        model, agent = make_model_and_agent()
         action = TrackedAction(agent, duration=10.0)
         action.start()
 
-        # Simulate 30% completion
-        action._progress = 0.3
-        action._event = None
+        # Advance the model to reach approximately 30% completion
+        model.run_for(action.duration * 0.3)
 
         action.interrupt()
 

--- a/tests/experimental/test_actions_interruption.py
+++ b/tests/experimental/test_actions_interruption.py
@@ -205,12 +205,12 @@ class TestActionCancel:
 
     def test_cancel_calls_on_interrupt(self):
         """Canceling should call on_interrupt with progress."""
-        _model, agent = make_model_and_agent()
+        model, agent = make_model_and_agent()
         action = TrackedAction(agent, duration=10.0)
         action.start()
 
-        action._progress = 0.7
-        action._event = None
+        # Advance model time so the action reaches ~70% progress naturally
+        model.run_for(action.duration * 0.7)
 
         action.cancel()
 

--- a/tests/experimental/test_actions_interruption.py
+++ b/tests/experimental/test_actions_interruption.py
@@ -240,39 +240,38 @@ class TestActionProgressTracking:
 
     def test_progress_frozen_on_interrupt(self):
         """Interrupting should freeze progress at that moment."""
-        _model, agent = make_model_and_agent()
+        model, agent = make_model_and_agent()
         action = TrackedAction(agent, duration=10.0)
         action.start()
 
-        # Simulate 40% elapsed
-        action._progress = 0.4
-        action._event = None
+        # Advance model time to simulate 40% elapsed progress.
+        model.run_for(4.0)
 
         action.interrupt()
 
-        # Progress should stay at 0.4
+        # Progress should stay at approximately 0.4
         assert abs(action.progress - 0.4) < 0.01
 
     def test_remaining_time_computed_live(self):
         """Remaining time should be computed based on duration and progress."""
-        _model, agent = make_model_and_agent()
+        model, agent = make_model_and_agent()
         action = TrackedAction(agent, duration=10.0)
         action.start()
 
-        action._progress = 0.25
-        action._event = None
+        # Advance model time to reach approximately 25% progress.
+        model.run_for(2.5)
 
         # 10 * (1 - 0.25) = 7.5
         assert abs(action.remaining_time - 7.5) < 0.01
 
     def test_elapsed_time_computed_correctly(self):
         """Elapsed time should be progress * duration."""
-        _model, agent = make_model_and_agent()
+        model, agent = make_model_and_agent()
         action = TrackedAction(agent, duration=20.0)
         action.start()
 
-        action._progress = 0.6
-        action._event = None
+        # Advance model time so that elapsed time is 12.0 (60% of 20.0).
+        model.run_for(12.0)
 
         # 20 * 0.6 = 12.0
         assert abs(action.elapsed_time - 12.0) < 0.01

--- a/tests/experimental/test_actions_interruption.py
+++ b/tests/experimental/test_actions_interruption.py
@@ -73,13 +73,12 @@ class TestActionInterruption:
 
     def test_interrupt_calls_on_interrupt_callback(self):
         """Interrupting an action should call on_interrupt with progress."""
-        _model, agent = make_model_and_agent()
+        model, agent = make_model_and_agent()
         action = TrackedAction(agent, duration=10.0)
         action.start()
 
-        # Manually set progress to simulate partial completion
-        action._progress = 0.5
-        action._event = None  # Cancel the scheduled event
+        # Advance model time to simulate partial completion (50% progress).
+        model.run_for(5.0)
 
         action.interrupt()
 


### PR DESCRIPTION
## Summary
- replace direct `_event` mutation in action interruption tests with `model.run_for(...)` plus public `interrupt()`/`cancel()` paths
- add retry logic for Playwright screenshots in examples viz tests to handle DOM re-render detachment

## Overview
This PR improves test stability in two places.

In the experimental Actions interruption tests, it replaces direct `_event` mutation with real model time advancement and public interruption/cancellation paths. This keeps the scheduler state accurate and avoids leaving stale scheduled events behind.

In the examples visualization tests, it adds retry logic around Playwright screenshots so transient Solara DOM re-renders do not fail the test with `Element is not attached to the DOM`.

## Motivation
These changes make the test suite more reliable and better aligned with Mesa's public APIs.

The action tests now exercise real scheduler behavior instead of bypassing it through private state mutation. The visualization test helper now tolerates harmless frontend rerenders that were causing flaky failures in CI.

## Testing
- `python -m pytest tests/experimental/test_actions_interruption.py`
- targeted verification for `tests/examples/test_examples_viz.py -k pd_grid_model`

