### PR TITLE
Pathfinding for Stacked Space

### DIFF
--- a/mesa/discrete_space/discrete_space.py
+++ b/mesa/discrete_space/discrete_space.py
@@ -19,7 +19,7 @@ import warnings
 from abc import ABC, abstractmethod
 from functools import cached_property
 from random import Random
-from typing import TypeVar
+from typing import Any, TypeVar
 
 import numpy as np
 
@@ -52,6 +52,7 @@ class DiscreteSpace[T: Cell](ABC):
     def __init__(
         self,
         capacity: int | None = None,
+        shared_dims: Any | None = None,
         cell_klass: type[T] = Cell,
         random: Random | None = None,
     ):
@@ -65,6 +66,8 @@ class DiscreteSpace[T: Cell](ABC):
         super().__init__()
         self.capacity = capacity
         self._cells: dict[tuple[int, ...], T] = {}
+        self.shared_dims = shared_dims
+
         if random is None:
             warnings.warn(
                 "Random number generator not specified, this can make models non-reproducible. Please pass a random number generator explicitly",
@@ -202,3 +205,42 @@ class DiscreteSpace[T: Cell](ABC):
             cell.connections = {
                 key: self._cells[coord] for key, coord in cell.connections.items()
             }
+
+    # Methods for stacked spaces
+
+    def add_agent(self, agent) -> None:
+        new_cell = self.find_nearest_cell(agent.position)
+        new_cell.add_agent(agent)
+
+        agent._mesa_locations[self] = new_cell
+
+    def remove_agent(self, agent) -> None:
+        agent._mesa_locations[self].remove_agent(agent)
+        del agent._mesa_locations[self]
+
+    def move_agent(self, agent, location) -> None:
+
+        if isinstance(location, np.ndarray):
+            new_location = self.find_nearest_cell(location)
+        elif isinstance(location, Cell):
+            new_location = location
+        else:
+            new_location = self._cells[location]
+
+        old_location = agent._mesa_locations.get(self)
+
+        if old_location is new_location:
+            return
+
+        if old_location is not None:
+            old_location.remove_agent(agent)
+
+        new_location.add_agent(agent)
+        agent._mesa_locations[self] = new_location
+
+        if (
+            not isinstance(location, np.ndarray)
+            and new_location.position is not None
+            and not np.array_equal(agent.position, new_location.position)
+        ):
+            agent.position = new_location.position

--- a/mesa/discrete_space/grid.py
+++ b/mesa/discrete_space/grid.py
@@ -258,8 +258,14 @@ class Grid(DiscreteSpace[T]):
             ValueError: If position is outside grid bounds and not a torus
         """
         if self.shared_dims is not None:
-            i = min(int(np.floor((position[0] - self.x_min) / self.dx)), self.dimensions[0] - 1)
-            j = min(int(np.floor((position[1] - self.y_min) / self.dy)), self.dimensions[1] - 1)
+            i = min(
+                int(np.floor((position[0] - self.x_min) / self.dx)),
+                self.dimensions[0] - 1,
+            )
+            j = min(
+                int(np.floor((position[1] - self.y_min) / self.dy)),
+                self.dimensions[1] - 1,
+            )
             coord = (i, j)
         else:
             coord = tuple(np.floor(position).astype(int))

--- a/mesa/discrete_space/grid.py
+++ b/mesa/discrete_space/grid.py
@@ -258,8 +258,8 @@ class Grid(DiscreteSpace[T]):
             ValueError: If position is outside grid bounds and not a torus
         """
         if self.shared_dims is not None:
-            i = int(np.floor((position[0] - self.x_min) / self.dx))
-            j = int(np.floor((position[1] - self.y_min) / self.dy))
+            i = min(int(np.floor((position[0] - self.x_min) / self.dx)), self.dimensions[0] - 1)
+            j = min(int(np.floor((position[1] - self.y_min) / self.dy)), self.dimensions[1] - 1)
             coord = (i, j)
         else:
             coord = tuple(np.floor(position).astype(int))

--- a/mesa/discrete_space/grid.py
+++ b/mesa/discrete_space/grid.py
@@ -86,6 +86,7 @@ class Grid(DiscreteSpace[T]):
         dimensions: Sequence[int],
         torus: bool = False,
         capacity: float | None = None,
+        shared_dims: Any | None = None,
         random: Random | None = None,
         cell_klass: type[T] = Cell,
     ) -> None:
@@ -98,11 +99,19 @@ class Grid(DiscreteSpace[T]):
             random: a random number generator
             cell_klass: the base class to use for the cells
         """
-        super().__init__(capacity=capacity, random=random, cell_klass=cell_klass)
+        super().__init__(
+            capacity=capacity,
+            shared_dims=shared_dims,
+            random=random,
+            cell_klass=cell_klass,
+        )
         self.torus = torus
         self.dimensions = dimensions
         self._try_random = True
         self._ndims = len(dimensions)
+        if self.shared_dims is not None:
+            self._adjust_scale()
+
         self._validate_parameters()
         self.cell_klass = type(
             "GridCell",
@@ -123,6 +132,15 @@ class Grid(DiscreteSpace[T]):
         self._celllist = list(self._cells.values())
         self._connect_cells()
         self.create_property_layer("empty", default_value=True, dtype=bool)
+
+    def _adjust_scale(self) -> None:
+
+        phys_x, phys_y = self.shared_dims.dimensions
+        self.x_min, self.x_max = phys_x[0], phys_x[1]
+        self.y_min, self.y_max = phys_y[0], phys_y[1]
+
+        self.dx = (self.x_max - self.x_min) / self.dimensions[0]
+        self.dy = (self.y_max - self.y_min) / self.dimensions[1]
 
     def create_property_layer(
         self,
@@ -239,8 +257,12 @@ class Grid(DiscreteSpace[T]):
         Raises:
             ValueError: If position is outside grid bounds and not a torus
         """
-        # Floor to get cell coordinate
-        coord = tuple(np.floor(position).astype(int))
+        if self.shared_dims is not None:
+            i = int(np.floor((position[0] - self.x_min) / self.dx))
+            j = int(np.floor((position[1] - self.y_min) / self.dy))
+            coord = (i, j)
+        else:
+            coord = tuple(np.floor(position).astype(int))
 
         # Handle torus wrapping
         if self.torus:

--- a/mesa/discrete_space/network.py
+++ b/mesa/discrete_space/network.py
@@ -31,6 +31,7 @@ class Network(DiscreteSpace[Cell]):
         self,
         G: Any,  # noqa: N803
         capacity: int | None = None,
+        shared_dims: Any | None = None,
         random: Random | None = None,
         cell_klass: type[Cell] = Cell,
         layout: Mapping | Callable | None = None,
@@ -53,7 +54,12 @@ class Network(DiscreteSpace[Cell]):
 
             layout = nx.circular_layout
 
-        super().__init__(capacity=capacity, random=random, cell_klass=cell_klass)
+        super().__init__(
+            capacity=capacity,
+            shared_dims=shared_dims,
+            random=random,
+            cell_klass=cell_klass,
+        )
         self.G = G
 
         # Resolve positions from the layout argument

--- a/mesa/discrete_space/voronoi.py
+++ b/mesa/discrete_space/voronoi.py
@@ -15,6 +15,7 @@ divisions, like territories, service areas, or natural regions.
 from collections.abc import Callable, Sequence
 from itertools import combinations
 from random import Random
+from typing import Any
 
 import numpy as np
 from scipy.spatial import KDTree
@@ -186,6 +187,7 @@ class VoronoiGrid(DiscreteSpace):
         self,
         centroids_coordinates: Sequence[Sequence[float]],
         capacity: int | Callable | None = None,
+        shared_dims: Any | None = None,
         random: Random | None = None,
         cell_klass: type[Cell] = Cell,
     ) -> None:
@@ -212,7 +214,10 @@ class VoronoiGrid(DiscreteSpace):
             numeric_capacity = capacity
 
         super().__init__(
-            capacity=numeric_capacity, random=random, cell_klass=cell_klass
+            capacity=numeric_capacity,
+            shared_dims=shared_dims,
+            random=random,
+            cell_klass=cell_klass,
         )
         self.centroids_coordinates = centroids_coordinates
         self.capacity_function = capacity_function

--- a/mesa/experimental/continuous_space/__init__.py
+++ b/mesa/experimental/continuous_space/__init__.py
@@ -4,5 +4,6 @@ from mesa.experimental.continuous_space.continuous_space import ContinuousSpace
 from mesa.experimental.continuous_space.continuous_space_agents import (
     ContinuousSpaceAgent,
 )
+from mesa.experimental.continuous_space.spatial_agents import SpatialAgent
 
-__all__ = ["ContinuousSpace", "ContinuousSpaceAgent"]
+__all__ = ["ContinuousSpace", "ContinuousSpaceAgent", "SpatialAgent"]

--- a/mesa/experimental/continuous_space/spatial_agents.py
+++ b/mesa/experimental/continuous_space/spatial_agents.py
@@ -60,6 +60,10 @@ class SpatialAgent(ContinuousSpaceAgent):
 
     @position.setter
     def position(self, value: np.ndarray) -> None:
+        # If position didn't change, no need to update
+        if self.position is not None and np.array_equal(self.position, value):
+            return
+        
         ContinuousSpaceAgent.position.fset(self, value)
 
         for space in self._spaces:

--- a/mesa/experimental/continuous_space/spatial_agents.py
+++ b/mesa/experimental/continuous_space/spatial_agents.py
@@ -1,4 +1,5 @@
 from collections.abc import MutableMapping
+
 import numpy as np
 
 from .continuous_space_agents import ContinuousSpaceAgent
@@ -28,7 +29,9 @@ class AgentLocations(MutableMapping):
             raise KeyError(f"Agent {self.agent.unique_id} is not in this space.")
 
     def __delitem__(self, space):
-        raise NotImplementedError("Use space.remove_agent() to remove an agent from a space.")
+        raise NotImplementedError(
+            "Use space.remove_agent() to remove an agent from a space."
+        )
 
     def __iter__(self):
         yield self.agent.space
@@ -41,13 +44,15 @@ class AgentLocations(MutableMapping):
 class SpatialAgent(ContinuousSpaceAgent):
     """An agent designed for the Stacked Spaces architecture."""
 
-    __slots__ = ["_spaces", "_mesa_locations", "_agent_locations"]
+    __slots__ = ["_agent_locations", "_mesa_locations", "_spaces"]
 
     def __init__(self, space, model):
         super().__init__(space, model)
         self._spaces = set()
         self._mesa_locations = {}
-        self._agent_locations = AgentLocations(self)    # proxy to handle _mesa_locations and routing
+        self._agent_locations = AgentLocations(
+            self
+        )  # proxy to handle _mesa_locations and routing
 
     @property
     def position(self) -> np.ndarray:
@@ -56,7 +61,7 @@ class SpatialAgent(ContinuousSpaceAgent):
     @position.setter
     def position(self, value: np.ndarray) -> None:
         ContinuousSpaceAgent.position.fset(self, value)
-        
+
         for space in self._spaces:
             space.move_agent(self, value)
 
@@ -67,7 +72,7 @@ class SpatialAgent(ContinuousSpaceAgent):
     def add_to_space(self, spaces):
         if not isinstance(spaces, (list, tuple, set)):
             spaces = [spaces]
-            
+
         for space in spaces:
             self._spaces.add(space)
             space.add_agent(self)
@@ -75,8 +80,8 @@ class SpatialAgent(ContinuousSpaceAgent):
     def remove(self) -> None:
         for space in list(self._spaces):
             space.remove_agent(self)
-                
+
         self._spaces.clear()
         self._mesa_locations.clear()
-        
+
         super().remove()

--- a/mesa/experimental/continuous_space/spatial_agents.py
+++ b/mesa/experimental/continuous_space/spatial_agents.py
@@ -63,7 +63,7 @@ class SpatialAgent(ContinuousSpaceAgent):
         # If position didn't change, no need to update
         if self.position is not None and np.array_equal(self.position, value):
             return
-        
+
         ContinuousSpaceAgent.position.fset(self, value)
 
         for space in self._spaces:

--- a/mesa/experimental/continuous_space/spatial_agents.py
+++ b/mesa/experimental/continuous_space/spatial_agents.py
@@ -1,0 +1,82 @@
+from collections.abc import MutableMapping
+import numpy as np
+
+from .continuous_space_agents import ContinuousSpaceAgent
+
+
+class AgentLocations(MutableMapping):
+    """Mapping protocol to handle multi-space routing via dictionary syntax."""
+
+    __slots__ = ["agent"]
+
+    def __init__(self, agent):
+        self.agent = agent
+
+    def __getitem__(self, space):
+        if space is self.agent.space:
+            return self.agent.position
+        if space not in self.agent._spaces:
+            raise KeyError(f"Agent {self.agent.unique_id} is not in this space.")
+        return self.agent._mesa_locations.get(space)
+
+    def __setitem__(self, space, location):
+        if space is self.agent.space:
+            self.agent.position = location
+        elif space in self.agent._spaces:
+            space.move_agent(self.agent, location)
+        else:
+            raise KeyError(f"Agent {self.agent.unique_id} is not in this space.")
+
+    def __delitem__(self, space):
+        raise NotImplementedError("Use space.remove_agent() to remove an agent from a space.")
+
+    def __iter__(self):
+        yield self.agent.space
+        yield from self.agent._spaces
+
+    def __len__(self):
+        return 1 + len(self.agent._spaces)
+
+
+class SpatialAgent(ContinuousSpaceAgent):
+    """An agent designed for the Stacked Spaces architecture."""
+
+    __slots__ = ["_spaces", "_mesa_locations", "_agent_locations"]
+
+    def __init__(self, space, model):
+        super().__init__(space, model)
+        self._spaces = set()
+        self._mesa_locations = {}
+        self._agent_locations = AgentLocations(self)    # proxy to handle _mesa_locations and routing
+
+    @property
+    def position(self) -> np.ndarray:
+        return super().position
+
+    @position.setter
+    def position(self, value: np.ndarray) -> None:
+        ContinuousSpaceAgent.position.fset(self, value)
+        
+        for space in self._spaces:
+            space.move_agent(self, value)
+
+    @property
+    def locations(self):
+        return self._agent_locations
+
+    def add_to_space(self, spaces):
+        if not isinstance(spaces, (list, tuple, set)):
+            spaces = [spaces]
+            
+        for space in spaces:
+            self._spaces.add(space)
+            space.add_agent(self)
+
+    def remove(self) -> None:
+        for space in list(self._spaces):
+            space.remove_agent(self)
+                
+        self._spaces.clear()
+        self._mesa_locations.clear()
+        
+        super().remove()


### PR DESCRIPTION
Pathfinding for adding stacked spaces architecture to Mesa. This builds upon the foundational ideas discussed in #2585 and #3458.

1. It introduces a bidirectional sync mechanism allowing agents to seamlessly operate across a continuous physical space (the primary space) and discrete patches (like `OrthogonalMooreGrid`), solving the multi-space routing challenge.
2. It introduces an unified agent `SpatialAgent` that automatically pushes updates from its continuous `position` downward to all registered discrete spaces.
3. Which example model can be used to best evaluate it?
4. Any suggestions on API ergonomics? Architecture? Naming?

Please see [Architectural Diagram](https://github.com/mesa/mesa/discussions/3458#discussioncomment-16129090)


