### PR TITLE
Document cell space migration guidance

### DIFF
--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -250,6 +250,84 @@ SolaraViz(
 * Ref: [PR #2827](https://github.com/mesa/mesa/pull/2827)
 
 
+## Mesa 3.1
+
+### Discrete cell spaces
+
+Mesa 3.1 includes the cell-space API under `mesa.experimental.cell_space`.
+Mesa 3.2 stabilizes that API as `mesa.discrete_space`. The older `mesa.space`
+grids, such as `SingleGrid`, `MultiGrid`, `HexSingleGrid`, and `HexMultiGrid`,
+remain available in
+Mesa 3.x, but are in maintenance-only mode. For new models on Mesa 3.2 or
+newer, prefer `mesa.discrete_space`; for existing models, migrate when you are
+ready to adopt the cell-based API.
+
+In the current stable namespace, the closest replacements are:
+
+- `mesa.space.SingleGrid` with Moore neighborhoods: `mesa.discrete_space.OrthogonalMooreGrid(..., capacity=1)`
+- `mesa.space.MultiGrid` with Moore neighborhoods: `mesa.discrete_space.OrthogonalMooreGrid`
+- `mesa.space.SingleGrid` with Von Neumann neighborhoods: `mesa.discrete_space.OrthogonalVonNeumannGrid(..., capacity=1)`
+- `mesa.space.MultiGrid` with Von Neumann neighborhoods: `mesa.discrete_space.OrthogonalVonNeumannGrid`
+- `mesa.space.HexSingleGrid`: `mesa.discrete_space.HexGrid(..., capacity=1)`
+- `mesa.space.HexMultiGrid`: `mesa.discrete_space.HexGrid`
+- `mesa.space.NetworkGrid`: `mesa.discrete_space.Network`
+
+If you are still on Mesa 3.1.x, use the same class names from
+`mesa.experimental.cell_space` instead.
+
+The new spaces are not drop-in replacements. Instead of storing only positions
+in the grid, the cell-space API exposes `Cell` objects. Agents that move
+through these spaces can subclass `CellAgent` and use the `cell` attribute to
+move between cells.
+
+The examples below use the Mesa 3.2+ stable namespace.
+
+```python
+# Old
+from mesa.space import MultiGrid
+
+self.grid = MultiGrid(width, height, torus=True)
+self.grid.place_agent(agent, (x, y))
+
+# New
+from mesa.discrete_space import CellAgent, OrthogonalMooreGrid
+
+
+class MyAgent(CellAgent):
+    pass
+
+
+self.grid = OrthogonalMooreGrid((width, height), torus=True, random=self.random)
+agent = MyAgent(self)
+agent.cell = self.grid[(x, y)]
+```
+
+For random placement, use the grid's cell collections:
+
+```python
+agent.cell = self.grid.all_cells.select_random_cell()
+```
+
+Cell spaces also support property layers for cell-level state:
+
+```python
+# Mesa 3.1 through 3.5
+elevation = self.grid.create_property_layer("elevation", default_value=0)
+elevation.data[:] = 1
+```
+
+In Mesa 4.0 and newer, `create_property_layer()` returns the attached NumPy
+array directly:
+
+```python
+# Mesa 4.0+
+elevation = self.grid.create_property_layer("elevation", default_value=0)
+elevation[:] = 1
+```
+
+- Ref: [Issue #2391](https://github.com/mesa/mesa/issues/2391)
+
+
 ## Mesa 3.0
 Mesa 3.0 introduces significant changes to core functionalities, including agent and model initialization, scheduling, and visualization. The guide below outlines these changes and provides instructions for migrating your existing Mesa projects to version 3.0.
 


### PR DESCRIPTION
## Describe your changes

Adds a Mesa 3.1 migration guide section for discrete cell spaces. It explains the Mesa 3.1 experimental namespace, the Mesa 3.2 stable namespace, and the Mesa 4 property-layer return value difference.

The section maps common legacy grids to current cell-space classes, including `capacity=1` for single-occupancy grids, and includes short examples for cell assignment, random placement, and property layers.

## Issue Link

Closes #2391

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (Addition or improvements to documentation)

## Checklist before requesting a review

- [x] My branch is up-to-date with the target branch - if not update your fork with the changes from the target branch (use `pull` with `--rebase` option if possible).
- [x] I have performed a self-review of my code
- [ ] For any new/modified functions/classes I have added docstrings that clearly describe its purpose, expected inputs and returned values. Not applicable, documentation only.
- [ ] I have placed in-line comments to clarify the intent of any hard-to-understand passages of my code. Not applicable, documentation only.
- [x] I have updated the documentation to cover introduced code changes
- [ ] I have added tests that prove my fix is effective or that my feature works. Not applicable, documentation only.
- [x] I have given the PR a name that clearly describes the change, written in imperative form ([context](https://www.gitkraken.com/learn/git/best-practices/git-commit-message#using-imperative-verb-form)).
- [ ] I have requested a reviewer and an assignee (assignee is responsible for merging)

## Validation

- `git diff --check`
- `python -m ruff check docs/migration_guide.md --no-cache`
- API smoke check covering `CellAgent`, `OrthogonalMooreGrid`, `OrthogonalVonNeumannGrid`, `HexGrid`, `capacity=1`, random cell selection, and Mesa 4 property-layer array mutation
- Source check against `v3.1.5`, `v3.2.0`, and `v3.5.1` confirming the 3.x property-layer return value
- `python -m sphinx -b html docs /tmp/mesa-docs-build -D nb_execution_mode=off`
- Checked rendered `migration_guide.html` for the new section and issue link

The Sphinx build succeeds with existing warnings unrelated to `docs/migration_guide.md`.

## Author checklist after completed review

- [ ] I have added a line to the CHANGELOG describing this change, in a section reflecting type of change. I did not add a changelog entry because this is a documentation guide update, but I can add one if requested.