### PR TITLE
Fix partial network edgecolors in matplotlib visualization

### DIFF
--- a/mesa/visualization/backends/matplotlib_backend.py
+++ b/mesa/visualization/backends/matplotlib_backend.py
@@ -163,15 +163,30 @@ class MatplotlibBackend(AbstractRenderer):
             arguments["marker"].append(aps.marker)
             arguments["zorder"].append(aps.zorder)
             arguments["alpha"].append(aps.alpha)
-            if aps.edgecolors is not None:
-                arguments["edgecolors"].append(aps.edgecolors)
+            arguments["edgecolors"].append(aps.edgecolors)
             arguments["linewidths"].append(aps.linewidths)
 
+        if any(edgecolor is not None for edgecolor in arguments["edgecolors"]):
+            arguments["edgecolors"] = [
+                edgecolor if edgecolor is not None else "none"
+                for edgecolor in arguments["edgecolors"]
+            ]
+        else:
+            arguments["edgecolors"] = []
+
         # Convert to numpy arrays
-        data = {
-            k: (np.asarray(v, dtype=object) if k == "marker" else np.asarray(v))
-            for k, v in arguments.items()
-        }
+        data = {}
+        for key, value in arguments.items():
+            if key == "marker":
+                data[key] = np.asarray(value, dtype=object)
+            elif key == "edgecolors":
+                try:
+                    data[key] = np.asarray(value)
+                except ValueError:
+                    data[key] = np.empty(len(value), dtype=object)
+                    data[key][:] = value
+            else:
+                data[key] = np.asarray(value)
 
         # Handle marker array specially to preserve tuples
         arr = np.empty(len(arguments["marker"]), dtype=object)

--- a/mesa/visualization/mpl_space_drawing.py
+++ b/mesa/visualization/mpl_space_drawing.py
@@ -159,14 +159,30 @@ def collect_agent_data(
         arguments["marker"].append(aps.marker)
         arguments["zorder"].append(aps.zorder)
         arguments["alpha"].append(aps.alpha)
-        if aps.edgecolors is not None:
-            arguments["edgecolors"].append(aps.edgecolors)
+        arguments["edgecolors"].append(aps.edgecolors)
         arguments["linewidths"].append(aps.linewidths)
 
-    data = {
-        k: (np.asarray(v, dtype=object) if k == "marker" else np.asarray(v))
-        for k, v in arguments.items()
-    }
+    if any(edgecolor is not None for edgecolor in arguments["edgecolors"]):
+        arguments["edgecolors"] = [
+            edgecolor if edgecolor is not None else "none"
+            for edgecolor in arguments["edgecolors"]
+        ]
+    else:
+        arguments["edgecolors"] = []
+
+    data = {}
+    for key, value in arguments.items():
+        if key == "marker":
+            data[key] = np.asarray(value, dtype=object)
+        elif key == "edgecolors":
+            try:
+                data[key] = np.asarray(value)
+            except ValueError:
+                data[key] = np.empty(len(value), dtype=object)
+                data[key][:] = value
+        else:
+            data[key] = np.asarray(value)
+
     # ensures that the tuples in marker dont get converted by numpy to an array resulting in a 2D array
     arr = np.empty(len(arguments["marker"]), dtype=object)
     arr[:] = arguments["marker"]

--- a/tests/visualization/test_backends.py
+++ b/tests/visualization/test_backends.py
@@ -95,6 +95,34 @@ def test_matplotlib_backend_collects_agent_data():
     assert "loc" in data and data["loc"].shape[0] == 1
 
 
+@pytest.mark.parametrize("edgecolor", ["black", (1.0, 0.0, 0.0, 1.0)])
+def test_matplotlib_backend_collects_partial_edgecolors(edgecolor):
+    """Collecting agent data preserves edgecolor alignment across agents."""
+    mb = MatplotlibBackend(space_drawer=MagicMock())
+
+    class DummyAgent:
+        position = (0, 0)
+        cell = types.SimpleNamespace(coordinate=(0, 0))
+
+        def __init__(self, kind):
+            self.kind = kind
+
+    class DummySpace:
+        agents: ClassVar[list] = [DummyAgent(0), DummyAgent(1)]
+
+    def agent_portrayal(agent):
+        portrayal = {"size": 5, "color": "red", "marker": "o"}
+        if agent.kind == 0:
+            portrayal["edgecolors"] = edgecolor
+        return portrayal
+
+    with pytest.warns(FutureWarning):
+        data = mb.collect_agent_data(DummySpace(), agent_portrayal)
+
+    assert data["edgecolors"].tolist() == [edgecolor, "none"]
+    assert len(data["edgecolors"]) == data["loc"].shape[0]
+
+
 def test_matplotlib_backend_draw_agents():
     """Test drawing agents."""
     mb = MatplotlibBackend(space_drawer=MagicMock())

--- a/tests/visualization/test_components_matplotlib.py
+++ b/tests/visualization/test_components_matplotlib.py
@@ -1,6 +1,7 @@
 """tests for matplotlib components."""
 
 import networkx as nx
+import pytest
 from matplotlib.figure import Figure
 
 from mesa import Model
@@ -136,6 +137,35 @@ def test_draw_network():
     fig = Figure()
     ax = fig.add_subplot()
     draw_network(grid, agent_portrayal, ax)
+
+
+@pytest.mark.parametrize("edgecolor", ["black", (1.0, 0.0, 0.0, 1.0)])
+def test_draw_network_with_partial_edgecolors(edgecolor):
+    """Network drawing handles edgecolors provided for only some agents."""
+    graph = nx.path_graph(2)
+    model = Model(rng=42)
+    grid = Network(graph, random=model.random, capacity=1, layout=nx.spring_layout)
+
+    for index, cell in enumerate(grid.all_cells):
+        agent = CellAgent(model)
+        agent.kind = index
+        agent.cell = cell
+
+    def partial_edgecolor_portrayal(agent):
+        portrayal = {
+            "size": 10,
+            "color": "tab:blue",
+            "marker": "o",
+            "zorder": 1,
+        }
+        if agent.kind == 0:
+            portrayal["edgecolors"] = edgecolor
+        return portrayal
+
+    fig = Figure()
+    ax = fig.add_subplot()
+    with pytest.warns(FutureWarning):
+        draw_network(grid, partial_edgecolor_portrayal, ax)
 
 
 def test_draw_property_layers():


### PR DESCRIPTION
> [!NOTE]
> Use this template for bug fixes only. For enhancements/new features, use the feature template and get maintainer approval in an issue/discussion before opening a PR.

### Pre-PR Checklist
- [x] This PR is a bug fix, not a new feature or enhancement.

### Summary
Fixes a matplotlib network visualization crash when only some agent portrayals include `edgecolors`.

### Bug / Issue
Fixes #2691.

`draw_network` expects per-agent style arrays to stay aligned. When an agent portrayal omitted `edgecolors`, the collectors skipped that entry, so the edgecolor array could be shorter than the node collection. Mixed string and RGBA tuple edgecolor values also need a one-dimensional object array so Matplotlib can consume them consistently.

### Implementation
- Collect one `edgecolors` entry per agent whenever any agent supplies edgecolors.
- Use Matplotlib `"none"` for agents that omit edgecolors.
- Preserve normal NumPy conversion where possible, and fall back to a one-dimensional object array for mixed color specifications such as RGBA tuples plus `"none"`.
- Apply the same behavior to both `draw_network` and `MatplotlibBackend.collect_agent_data`.
- Add regression tests for partial edgecolors with string colors and RGBA tuple colors.

### Testing
- `uv run --extra viz --extra network --with pytest pytest -p no:cacheprovider tests/visualization/test_components_matplotlib.py::test_draw_network_with_partial_edgecolors tests/visualization/test_backends.py::test_matplotlib_backend_collects_partial_edgecolors -q` -> 4 passed
- `uv run --extra viz --extra network --with pytest pytest -p no:cacheprovider tests/visualization/test_components_matplotlib.py tests/visualization/test_backends.py -q` -> 30 passed
- `uv run --extra viz --extra network --with pytest --with ruff ruff check --no-cache mesa/visualization/mpl_space_drawing.py mesa/visualization/backends/matplotlib_backend.py tests/visualization/test_components_matplotlib.py tests/visualization/test_backends.py` -> passed
- `git diff --check` -> passed

No screenshots are attached because the regression was an exception before rendering completed; the automated Matplotlib tests cover the before/after failure mode.

### Additional Notes
This is scoped to matplotlib visualization style collection. It does not change public APIs, dependencies, schemas, or CI configuration.