### PR TITLE
Fix get_k_nearest_agents crash, select_random_cell API consistency, agent_positions init

### DIFF
--- a/mesa/agentset.py
+++ b/mesa/agentset.py
@@ -390,7 +390,7 @@ class AgentSet[A: Agent](AbstractAgentSet[A], Sequence[A]):
             self.random = random
         else:
             # all agents in an AgentSet should share the same model, just take it from first
-            self.random = self._agents.keys().__next__().model.random
+            self.random = next(iter(self._agents.keys())).model.random
 
     def __len__(self) -> int:
         """Return the number of agents in the AgentSet."""

--- a/mesa/discrete_space/cell_collection.py
+++ b/mesa/discrete_space/cell_collection.py
@@ -98,8 +98,23 @@ class CellCollection[T: Cell]:
     def agents(self) -> Iterable[CellAgent]:  # noqa
         return itertools.chain.from_iterable(self._cells.values())
 
-    def select_random_cell(self) -> T:
-        """Select a random cell."""
+    def select_random_cell(self, default=RAISES) -> T | None:
+        """Select a random cell from the collection.
+
+        Args:
+            default: Value to return if the collection is empty.
+                     If not provided, raises LookupError.
+
+        Returns:
+            T: A random cell, or the default value if provided and collection is empty.
+
+        Raises:
+            LookupError: If collection is empty and no default is provided.
+        """
+        if not self._cells:
+            if default is RAISES:
+                raise LookupError("Cannot select random cell from empty collection")
+            return default
         return self.random.choice(self.cells)
 
     def select_random_agent(self, default=RAISES) -> CellAgent | None:

--- a/mesa/experimental/continuous_space/continuous_space.py
+++ b/mesa/experimental/continuous_space/continuous_space.py
@@ -88,9 +88,7 @@ class ContinuousSpace:
         self._agent_positions: np.array = np.empty(
             (n_agents, self.dimensions.shape[0]), dtype=float
         )
-        self.agent_positions: (
-            np.array
-        )  # a view on _agent_positions containing all active positions
+        self.agent_positions: np.array = self._agent_positions[0:0]  # empty view until agents are added
 
         # the list of agents in the space
         self.active_agents = []
@@ -253,13 +251,20 @@ class ContinuousSpace:
         Notes:
             This method returns exactly k agents, ignoring ties. In case of ties, the
             earlier an agent is inserted the higher it will rank.
+            If k exceeds the total number of agents, all agents are returned.
 
         """
         dists, agents = self.calculate_distances(point)
+        n = len(dists)
+
+        if n == 0:
+            return [], np.array([])
+
+        if k >= n:
+            return list(agents), dists
 
         indices = np.argpartition(dists, k)[:k]
-        agents = [agents[i] for i in indices]
-        return agents, dists[indices]
+        return [agents[i] for i in indices], dists[indices]
 
     def in_bounds(self, point: ArrayLike) -> bool:
         """Check if point is inside the bounds of the space."""

--- a/mesa/experimental/continuous_space/continuous_space.py
+++ b/mesa/experimental/continuous_space/continuous_space.py
@@ -88,7 +88,9 @@ class ContinuousSpace:
         self._agent_positions: np.array = np.empty(
             (n_agents, self.dimensions.shape[0]), dtype=float
         )
-        self.agent_positions: np.array = self._agent_positions[0:0]  # empty view until agents are added
+        self.agent_positions: np.array = self._agent_positions[
+            0:0
+        ]  # empty view until agents are added
 
         # the list of agents in the space
         self.active_agents = []

--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -1097,6 +1097,23 @@ def test_select_random_agent_empty_safe():
     assert empty_collection.select_random_agent(default="Empty") == "Empty"
 
 
+def test_select_random_cell_empty_safe():
+    """Test that select_random_cell raises LookupError on empty collection and respects default."""
+    rng = random.Random(42)
+    empty_collection = CellCollection([], random=rng)
+    with pytest.raises(LookupError):
+        empty_collection.select_random_cell()
+    assert empty_collection.select_random_cell(default=None) is None
+    assert empty_collection.select_random_cell(default="fallback") == "fallback"
+
+    # Non-empty collection should still return a cell
+    n = 5
+    cells = [Cell((i,), random=rng) for i in range(n)]
+    collection = CellCollection(cells, random=rng)
+    chosen = collection.select_random_cell()
+    assert chosen in collection
+
+
 def test_infinite_loop_on_full_grid():
     """Test that select_random_empty_cell raises ValueError with informative message on a full grid."""
     # 1. Create a small 2x2 model

--- a/tests/experimental/test_continuous_space.py
+++ b/tests/experimental/test_continuous_space.py
@@ -320,6 +320,32 @@ def test_continuous_space_get_k_nearest_agents():  # noqa: D103
     assert np.allclose(distances, [0.1, 0.1])
 
 
+def test_get_k_nearest_agents_k_exceeds_count():
+    """Test get_k_nearest_agents returns all agents when k >= number of agents."""
+    model = Model(rng=42)
+    dimensions = np.asarray([[0, 1], [0, 1]])
+    space = ContinuousSpace(dimensions, torus=False, random=model.random)
+
+    for pos in [[0.1, 0.1], [0.9, 0.9], [0.5, 0.5]]:
+        agent = ContinuousSpaceAgent(space, model)
+        agent.position = pos
+
+    # k exactly equals agent count
+    agents, distances = space.get_k_nearest_agents([0.5, 0.5], k=3)
+    assert len(agents) == 3
+
+    # k greater than agent count
+    agents, distances = space.get_k_nearest_agents([0.5, 0.5], k=10)
+    assert len(agents) == 3
+    assert len(distances) == 3
+
+    # empty space
+    empty_space = ContinuousSpace(dimensions, torus=False, random=model.random)
+    agents, distances = empty_space.get_k_nearest_agents([0.5, 0.5], k=1)
+    assert agents == []
+    assert len(distances) == 0
+
+
 def test_continuous_space_get_agents_in_radius():  # noqa: D103
     # non torus
     model = Model(rng=42)


### PR DESCRIPTION
## Summary
- `get_k_nearest_agents(k)` crashed with `ValueError` when `k >= number of agents`; now returns all available agents gracefully
- `agent_positions` was never initialized in `ContinuousSpace.__init__`, causing `AttributeError` on any distance query against an empty space
- `select_random_cell()` raised a bare `IndexError` on empty collections; added a `default` parameter matching `select_random_agent()` API
- `AgentSet.__init__` used non-idiomatic `.__next__()` instead of `next(iter(...))`

## Test plan
- [x] `test_get_k_nearest_agents_k_exceeds_count` — covers k==n, k>n, empty space
- [x] `test_select_random_cell_empty_safe` — covers LookupError, custom default, normal case
- [x] Full test suite: 496 passed, 0 regressions
