### PR TITLE
Fix get_k_nearest_agents crash when k >= number of agents

### DIFF
--- a/mesa/experimental/continuous_space/continuous_space.py
+++ b/mesa/experimental/continuous_space/continuous_space.py
@@ -88,7 +88,9 @@ class ContinuousSpace:
         self._agent_positions: np.array = np.empty(
             (n_agents, self.dimensions.shape[0]), dtype=float
         )
-        self.agent_positions: np.array = self._agent_positions[0:0]  # empty view, updated in _add_agent
+        self.agent_positions: np.array = self._agent_positions[
+            0:0
+        ]  # empty view, updated in _add_agent
 
         # the list of agents in the space
         self.active_agents = []

--- a/mesa/experimental/continuous_space/continuous_space.py
+++ b/mesa/experimental/continuous_space/continuous_space.py
@@ -88,9 +88,7 @@ class ContinuousSpace:
         self._agent_positions: np.array = np.empty(
             (n_agents, self.dimensions.shape[0]), dtype=float
         )
-        self.agent_positions: (
-            np.array
-        )  # a view on _agent_positions containing all active positions
+        self.agent_positions: np.array = self._agent_positions[0:0]  # empty view, updated in _add_agent
 
         # the list of agents in the space
         self.active_agents = []
@@ -253,13 +251,20 @@ class ContinuousSpace:
         Notes:
             This method returns exactly k agents, ignoring ties. In case of ties, the
             earlier an agent is inserted the higher it will rank.
+            If k exceeds the number of agents, all agents are returned.
 
         """
         dists, agents = self.calculate_distances(point)
+        n = len(dists)
+
+        if n == 0:
+            return [], np.array([])
+
+        if k >= n:
+            return list(agents), dists
 
         indices = np.argpartition(dists, k)[:k]
-        agents = [agents[i] for i in indices]
-        return agents, dists[indices]
+        return [agents[i] for i in indices], dists[indices]
 
     def in_bounds(self, point: ArrayLike) -> bool:
         """Check if point is inside the bounds of the space."""

--- a/tests/experimental/test_continuous_space.py
+++ b/tests/experimental/test_continuous_space.py
@@ -320,6 +320,31 @@ def test_continuous_space_get_k_nearest_agents():  # noqa: D103
     assert np.allclose(distances, [0.1, 0.1])
 
 
+def test_get_k_nearest_agents_k_exceeds_count():  # noqa: D103
+    model = Model(rng=42)
+    dimensions = np.asarray([[0, 1], [0, 1]])
+    space = ContinuousSpace(dimensions, torus=False, random=model.random)
+
+    for pos in [[0.1, 0.1], [0.9, 0.9], [0.5, 0.5]]:
+        agent = ContinuousSpaceAgent(space, model)
+        agent.position = pos
+
+    # k equals agent count — should return all agents
+    agents, distances = space.get_k_nearest_agents([0.5, 0.5], k=3)
+    assert len(agents) == 3
+
+    # k greater than agent count — should return all agents
+    agents, distances = space.get_k_nearest_agents([0.5, 0.5], k=10)
+    assert len(agents) == 3
+    assert len(distances) == 3
+
+    # empty space — should return empty lists without raising
+    empty_space = ContinuousSpace(dimensions, torus=False, random=model.random)
+    agents, distances = empty_space.get_k_nearest_agents([0.5, 0.5], k=1)
+    assert agents == []
+    assert len(distances) == 0
+
+
 def test_continuous_space_get_agents_in_radius():  # noqa: D103
     # non torus
     model = Model(rng=42)


### PR DESCRIPTION
## What

`get_k_nearest_agents` raises `ValueError` from `np.argpartition` whenever
`k >= number of agents in the space`, because `np.argpartition(arr, kth)`
requires `kth < arr.size`.

Additionally, `agent_positions` was declared as a bare type annotation in
`__init__` and never assigned — any distance query on an empty space raised
`AttributeError`. This was caught while writing the test for the above.

## Fix

- Guard in `get_k_nearest_agents`: if `k >= n`, return all agents directly.
  If the space is empty, return `([], np.array([]))`.
- Initialise `agent_positions` to an empty slice in `__init__` so distance
  methods work on a freshly-created space with no agents.

## Test

Added `test_get_k_nearest_agents_k_exceeds_count` covering:
- `k` equal to agent count
- `k` greater than agent count  
- empty space
