### PR TITLE
fix: remove trailing comma in switcher.json

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -18,6 +18,6 @@
     "name": "3.5.1",
     "version": "v3.5.1",
     "url": "https://mesa.readthedocs.io/en/v3.5.1/"
-  },
+  }
 
 ]

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -12,7 +12,7 @@
   {
     "name": "2.4.0",
     "version": "v2.4.0",
-    "url": "https://mesa.readthedocs.io/en/v2.4.0/"
+    "url": "https://mesa.readthedocs.io/v2.4.0/"
   },
   {
     "name": "3.5.1",

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -17,7 +17,7 @@
   {
     "name": "3.5.1",
     "version": "v3.5.1",
-    "url": "https://mesa.readthedocs.io/en/v3.5.1/"
+    "url": "https://mesa.readthedocs.io/v3.5.1/"
   }
 
 ]


### PR DESCRIPTION
Fixes #3720 
This PR fixes the version selector dropdown that was showing a blank box instead of displaying available versions.
The **switcher.json** file had a comma after the last JSON object, which caused invalid JSON and prevented the version dropdown from rendering correctly. 

Key Fix: Removed the comma from  @**switcher.json**
