### PR TITLE
Testing RTD Dropdown Fix

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -18,6 +18,6 @@
     "name": "3.5.1",
     "version": "v3.5.1",
     "url": "https://mesa.readthedocs.io/en/v3.5.1/"
-  },
+  }
 
 ]

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -12,12 +12,12 @@
   {
     "name": "2.4.0",
     "version": "v2.4.0",
-    "url": "https://mesa.readthedocs.io/en/v2.4.0/"
+    "url": "https://mesa.readthedocs.io/v2.4.0/"
   },
   {
     "name": "3.5.1",
     "version": "v3.5.1",
-    "url": "https://mesa.readthedocs.io/en/v3.5.1/"
+    "url": "https://mesa.readthedocs.io/v3.5.1/"
   }
 
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,7 +130,7 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "navbar_start": ["navbar-logo", "version-switcher"],
     "switcher": {
-        "json_url": "https://mesa.readthedocs.io/en/stable/_static/switcher.json",
+        "json_url": "_static/switcher.json",
         "version_match": os.environ.get("READTHEDOCS_VERSION", release),
     },
 }


### PR DESCRIPTION
_This PR is specifically to check the Read the Docs build and verify the solution for the empty version dropdown mentioned in #3722_

_It temporarily changes the `json_url` in `conf.py` to a relative path (`_static/switcher.json`). This bypasses the hardcoded live stable URL, forcing the CI to build using the locally corrected JSON syntax on this branch_