### PR TITLE
Make CellCollection.select_random_cell empty-safe with a default parameter

### DIFF
--- a/mesa/discrete_space/cell_collection.py
+++ b/mesa/discrete_space/cell_collection.py
@@ -98,8 +98,24 @@ class CellCollection[T: Cell]:
     def agents(self) -> Iterable[CellAgent]:  # noqa
         return itertools.chain.from_iterable(self._cells.values())
 
-    def select_random_cell(self) -> T:
-        """Select a random cell."""
+    def select_random_cell(self, default=RAISES) -> T | None:
+        """Select a random cell from the collection.
+
+        Args:
+            default: Value to return if the collection is empty.
+                     If not provided, raises LookupError.
+
+        Returns:
+            T: A random cell, or the default value if provided and collection is empty.
+
+        Raises:
+            LookupError: If collection is empty and no default is provided.
+        """
+        if not self._cells:
+            if default is RAISES:
+                raise LookupError("Cannot select random cell from empty collection")
+            return default
+
         return self.random.choice(self.cells)
 
     def select_random_agent(self, default=RAISES) -> CellAgent | None:

--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -1097,6 +1097,20 @@ def test_select_random_agent_empty_safe():
     assert empty_collection.select_random_agent(default="Empty") == "Empty"
 
 
+def test_select_random_cell_empty_safe():
+    """Test that select_random_cell raises LookupError on an empty collection and honors default."""
+    rng = random.Random(42)
+    empty_collection = CellCollection([], random=rng)
+    with pytest.raises(LookupError):
+        empty_collection.select_random_cell()
+    assert empty_collection.select_random_cell(default=None) is None
+    assert empty_collection.select_random_cell(default="Empty") == "Empty"
+
+    # A non-empty collection still returns a cell from the collection
+    collection = CellCollection([Cell((i,), random=rng) for i in range(5)], random=rng)
+    assert collection.select_random_cell() in collection
+
+
 def test_infinite_loop_on_full_grid():
     """Test that select_random_empty_cell raises ValueError with informative message on a full grid."""
     # 1. Create a small 2x2 model


### PR DESCRIPTION
## What

`CellCollection.select_random_cell()` calls `self.random.choice(self.cells)`
directly, which raises a bare `IndexError` with no context when the collection
is empty.

The sibling method `select_random_agent()` already handles this gracefully via a
`default` parameter (returning the default when empty, or raising `LookupError`
otherwise). This PR brings `select_random_cell()` in line with that existing API
so the two methods behave consistently.

## Change

- `select_random_cell(default=RAISES)`: returns `default` when the collection is
  empty, or raises `LookupError` with a clear message if no default is given.
  Non-empty behavior is unchanged.

This mirrors the existing `select_random_agent` signature and semantics exactly —
no new patterns introduced.

## Test

Added `test_select_random_cell_empty_safe`, matching the existing
`test_select_random_agent_empty_safe`:
- raises `LookupError` on an empty collection
- returns the provided `default` when empty
- still returns a valid cell for a non-empty collection

All 88 tests in `tests/discrete_space/test_discrete_space.py` pass; `ruff` clean.
