### PR TITLE
Fix AttributeError when accessing Cell.empty before adding/removing agents

### DIFF
--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -104,6 +104,7 @@ class Cell:
         self._agents: list[
             CellAgent
         ] = []  # TODO:: change to AgentSet or weakrefs? (neither is very performant, )
+        self._empty: bool = True  # a freshly created cell holds no agents
         self.capacity: int | None = capacity
         self.properties: dict[
             Coordinate, object

--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -668,6 +668,30 @@ def test_cell():
         cell_zero.add_agent(CellAgent(model))
 
 
+def test_cell_empty_attribute_initialized():
+    """A freshly created Cell exposes `empty` without first adding/removing an agent.
+
+    Cells that are not grid cells (e.g. those in Network and VoronoiGrid) have no
+    `empty` property layer overriding the attribute, so reading `cell.empty` must
+    work straight after construction. Regression test for the uninitialized
+    `_empty` slot which raised AttributeError.
+    """
+    model = Model()
+    cell = Cell((0,), capacity=None, random=random.Random())
+
+    # readable immediately after construction, and consistent with is_empty
+    assert cell.empty is True
+    assert cell.empty == cell.is_empty
+
+    # tracks agent occupancy
+    agent = CellAgent(model)
+    cell.add_agent(agent)
+    assert cell.empty is False
+
+    cell.remove_agent(agent)
+    assert cell.empty is True
+
+
 def test_cell_deepcopy():
     """Verify that Cell deepcopy correctly handles circular references via coordinates."""
     rng = random.Random(42)


### PR DESCRIPTION
## What

Accessing `cell.empty` on a freshly created `Cell` raises:

    AttributeError: 'Cell' object has no attribute '_empty'

`_empty` is declared in `Cell.__slots__` and the `empty` property getter returns
`self._empty`, but `Cell.__init__` never initializes it. The attribute only comes
into existence after the first `add_agent`/`remove_agent` call (which assign
`self.empty`).

This affects every cell that is **not** a grid cell — i.e. cells in `Network`
and `VoronoiGrid`. `GridCell` is unaffected because the grid attaches an `"empty"`
property-layer accessor that overrides the attribute.

## Reproduction

```python
import random
from mesa.discrete_space import Cell

c = Cell((0,), random=random.Random())
c.empty          # AttributeError: 'Cell' object has no attribute '_empty'
