### PR TITLE
Reject non-positive callable Schedule intervals in EventGenerator

### DIFF
--- a/mesa/time/events.py
+++ b/mesa/time/events.py
@@ -263,7 +263,7 @@ class EventGenerator:
         """Get the next interval value."""
         if callable(self.schedule.interval):
             interval = self.schedule.interval(self.model)
-            if interval < 0:
+            if interval <= 0:
                 raise ValueError(f"Interval must be > 0, got {interval}")
             return interval
         return self.schedule.interval

--- a/tests/time/test_events.py
+++ b/tests/time/test_events.py
@@ -506,6 +506,27 @@ class TestEventGeneratorInit:
         with pytest.raises(ValueError, match="alive"):
             EventGenerator(model, lambda: 10, Schedule(interval=1.0))
 
+    def test_rejects_nonpositive_callable_interval(self, setup):
+        """A callable interval must follow the same > 0 rule as a fixed interval.
+
+        ``Schedule(interval=0)`` is rejected at construction, but a callable that
+        returns 0 was previously accepted, which would schedule the next event at
+        the current time. The runtime check must reject both 0 and negatives.
+        """
+        model, fn = setup
+
+        gen = EventGenerator(model, fn, Schedule(interval=lambda m: 0))
+        with pytest.raises(ValueError, match="> 0"):
+            gen._get_interval()
+
+        gen = EventGenerator(model, fn, Schedule(interval=lambda m: -1))
+        with pytest.raises(ValueError, match="> 0"):
+            gen._get_interval()
+
+        # A positive callable interval is returned unchanged.
+        gen = EventGenerator(model, fn, Schedule(interval=lambda m: 2.0))
+        assert gen._get_interval() == 2.0
+
 
 class TestEventGeneratorStartStop:
     def test_start_with_schedule_start(self, setup):


### PR DESCRIPTION
## What

`Schedule(interval=0)` is rejected at construction (`interval must be > 0`), but
a callable interval that returns `0` was accepted at runtime. The check in
`EventGenerator._get_interval` used `interval < 0`, while its error message says
`must be > 0`, so `0` passed through.

An interval of `0` schedules the next recurring event at the current time, which
can cause repeated same-timestamp rescheduling, so it should be rejected just like
a fixed interval of `0`.

## Reproduction

```python
from mesa import Model
from mesa.time import Schedule, EventGenerator

def cb():
    pass

Schedule(interval=0)            # ValueError: interval must be > 0   (correct)

m = Model(rng=1)
gen = EventGenerator(m, cb, Schedule(interval=lambda model: 0))
gen._get_interval()             # returns 0  (inconsistent: should raise)
```

## Fix

Changed the guard in `_get_interval` from `interval < 0` to `interval <= 0`, so a
callable interval follows the same `> 0` rule as a fixed interval. The existing
error message is already correct.

## Test

Added `test_rejects_nonpositive_callable_interval`: a callable returning `0` or a
negative value raises `ValueError`, and a positive value is returned unchanged.
Full `tests/time/` suite passes under `-Werror`; ruff clean.
