### PR TITLE
Preserve read_only property layers across Grid pickling and deepcopy

### DIFF
--- a/mesa/discrete_space/grid.py
+++ b/mesa/discrete_space/grid.py
@@ -396,23 +396,34 @@ class Grid(DiscreteSpace[T]):
         """Custom __getstate__ for handling dynamic GridCell class and property_layer accessors."""
         state = super().__getstate__()
         state = {k: v for k, v in state.items() if k != "cell_klass"}
+        # Record which property_layers are read-only (their accessor has no setter)
+        # so the read-only constraint survives the pickle round trip.
+        state["_read_only_property_layers"] = {
+            name
+            for name in self.property_layers
+            if getattr(self.cell_klass, name).fset is None
+        }
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         """Restore state and re-attach property_layer accessors to the cell class."""
+        read_only_layers = state.pop("_read_only_property_layers", set())
         super().__setstate__(state)
         for name, array in self.property_layers.items():
-            setattr(
-                self.cell_klass,
-                name,
-                property(
+            if name in read_only_layers:
+                accessor = property(
+                    lambda self_cell, a=array: a[self_cell.coordinate],
+                    doc=f"property_layer '{name}'",
+                )
+            else:
+                accessor = property(
                     lambda self_cell, a=array: a[self_cell.coordinate],
                     lambda self_cell, v, a=array: a.__setitem__(
                         self_cell.coordinate, v
                     ),
                     doc=f"property_layer '{name}'",
-                ),
-            )
+                )
+            setattr(self.cell_klass, name, accessor)
 
 
 class OrthogonalMooreGrid(Grid[T]):

--- a/mesa/discrete_space/grid.py
+++ b/mesa/discrete_space/grid.py
@@ -110,6 +110,9 @@ class Grid(DiscreteSpace[T]):
             {"property_layers": set(), "__slots__": ()},
         )
         self.property_layers: dict[str, np.ndarray] = {}
+        # Track which property layers are read-only so the constraint survives
+        # pickling and deepcopy (see __getstate__/__setstate__).
+        self._read_only_layers: set[str] = set()
 
         # we register the pickle_gridcell helper function
         copyreg.pickle(self.cell_klass, pickle_gridcell)
@@ -173,6 +176,7 @@ class Grid(DiscreteSpace[T]):
         del self.property_layers[name]
         delattr(self.cell_klass, name)
         self.cell_klass.property_layers.discard(name)
+        self._read_only_layers.discard(name)
 
     def _attach_property_layer(
         self, name: str, array: np.ndarray, read_only: bool = False
@@ -212,6 +216,8 @@ class Grid(DiscreteSpace[T]):
         )
         setattr(self.cell_klass, name, accessor)
         self.cell_klass.property_layers.add(name)
+        if read_only:
+            self._read_only_layers.add(name)
 
     def get_neighborhood_mask(
         self, coordinate, include_center: bool = True, radius: int = 1
@@ -396,19 +402,18 @@ class Grid(DiscreteSpace[T]):
         """Custom __getstate__ for handling dynamic GridCell class and property_layer accessors."""
         state = super().__getstate__()
         state = {k: v for k, v in state.items() if k != "cell_klass"}
-        # Record which property_layers are read-only (their accessor has no setter)
-        # so the read-only constraint survives the pickle round trip.
-        state["_read_only_property_layers"] = {
-            name
-            for name in self.property_layers
-            if getattr(self.cell_klass, name).fset is None
-        }
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
-        """Restore state and re-attach property_layer accessors to the cell class."""
-        read_only_layers = state.pop("_read_only_property_layers", set())
+        """Restore state and re-attach property_layer accessors to the cell class.
+
+        Read-only layers (tracked in ``_read_only_layers``) are restored without a
+        setter so the read-only constraint survives the round trip.
+        """
         super().__setstate__(state)
+        # Older pickles may predate _read_only_layers; default to no read-only layers.
+        read_only_layers = getattr(self, "_read_only_layers", set())
+        self._read_only_layers = read_only_layers
         for name, array in self.property_layers.items():
             if name in read_only_layers:
                 accessor = property(

--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -903,6 +903,29 @@ def test_copy_pickle_with_property_layers():
     assert grid2._cells[(0, 0)].empty == grid2.property_layers["empty"][0, 0]
 
 
+def test_read_only_property_layer_survives_pickle_and_deepcopy():
+    """A read-only property layer must stay read-only after pickling/deepcopy.
+
+    Previously Grid.__setstate__ rebuilt every property layer with a setter,
+    silently dropping the read_only restriction on the round trip.
+    """
+    grid = OrthogonalMooreGrid((3, 3), torus=False, random=random.Random(42))
+    grid.create_property_layer("protected", default_value=0.0, read_only=True)
+    grid.create_property_layer("sugar", default_value=1.0, read_only=False)
+
+    for label, restored in [
+        ("deepcopy", copy.deepcopy(grid)),
+        ("pickle", pickle.loads(pickle.dumps(grid))),  # noqa: S301
+    ]:
+        cell = restored._cells[(0, 0)]
+        # read-only layer must still reject writes
+        with pytest.raises(AttributeError):
+            cell.protected = 99.0
+        # read-write layer must still accept writes
+        cell.sugar = 5.0
+        assert cell.sugar == 5.0, label
+
+
 def test_multiple_property_layers():
     """Test initialization of DiscreteSpace with Property Layers."""
     dimensions = (5, 5)


### PR DESCRIPTION
Closes #3730

## What

Read-only property layers on a `Grid` became writable again after the grid was
pickled (or deepcopied). `Grid.__setstate__` rebuilt every property layer with both
a getter and a setter, ignoring the original `read_only` flag, so the restriction
that `_attach_property_layer` set up was silently lost on the round trip.

## Reproduction

```python
import pickle
from mesa import Model
from mesa.discrete_space.grid import OrthogonalMooreGrid

grid = OrthogonalMooreGrid(dimensions=(3, 3), random=Model().random)
grid.create_property_layer("protected", default_value=0.0, read_only=True)

grid2 = pickle.loads(pickle.dumps(grid))
grid2._cells[(0, 0)].protected = 99.0   # expected AttributeError, but it succeeded
```

## Fix

The read-only status is now carried through the pickle round trip:

- `__getstate__` records the set of read-only layers (those whose cell-class
  accessor has `fset is None`).
- `__setstate__` rebuilds each accessor as getter-only when the layer was read-only,
  and getter+setter otherwise, mirroring `_attach_property_layer`.

The change is confined to the two pickle methods. `copy.deepcopy` uses the same
methods, so it is fixed too.

## Test

Added `test_read_only_property_layer_survives_pickle_and_deepcopy`: after both
`deepcopy` and `pickle` round trips, a read-only layer still raises `AttributeError`
on write, while a read-write layer remains writable.

Full `tests/discrete_space/` suite passes under `-Werror`; ruff clean.
