### PR TITLE
Return descriptor on class-level Observable access

### DIFF
--- a/mesa/experimental/mesa_signals/core.py
+++ b/mesa/experimental/mesa_signals/core.py
@@ -64,6 +64,11 @@ class BaseObservable:
         self.fallback_value = fallback_value
 
     def __get__(self, instance: HasEmitters, owner):  # noqa: D105
+        # Class-level access (e.g. ``MyAgent.value``) returns the descriptor
+        # itself, following the standard descriptor protocol used by ``property``.
+        if instance is None:
+            return self
+
         value = getattr(instance, self.private_name)
 
         if CURRENT_COMPUTED is not None:

--- a/tests/experimental/test_mesa_signals.py
+++ b/tests/experimental/test_mesa_signals.py
@@ -42,6 +42,31 @@ def test_observables():
     handler.assert_called_once()
 
 
+def test_observable_class_level_access():
+    """Accessing an Observable on the class returns the descriptor, not an error.
+
+    Standard descriptors (like ``property``) return themselves when accessed via
+    the class. Previously ``BaseObservable.__get__`` did ``getattr(None, ...)``,
+    raising AttributeError and making ``hasattr(cls, name)`` return False.
+    """
+
+    class MyAgent(Agent, HasEmitters):
+        value = Observable()
+
+        def __init__(self, model):
+            super().__init__(model)
+            self.value = 10
+
+    # Class-level access returns the descriptor itself.
+    assert isinstance(MyAgent.value, Observable)
+    # Introspection works.
+    assert hasattr(MyAgent, "value")
+    # Instance access is unchanged.
+    model = Model(rng=42)
+    agent = MyAgent(model)
+    assert agent.value == 10
+
+
 def test_HasEmitters():
     """Test Observable."""
 


### PR DESCRIPTION
Closes #3732

## What

Accessing an `Observable` attribute on the class (e.g. `MyAgent.value`) raised
`AttributeError` instead of returning the descriptor. `BaseObservable.__get__`
called `getattr(instance, self.private_name)` unconditionally, so class-level
access (where Python passes `instance=None`) became `getattr(None, "_value")`.

This also made `hasattr(MyAgent, "value")` return `False`, since `hasattr`
swallows the `AttributeError`, breaking normal class-level introspection.

## Fix

Added the standard descriptor-protocol guard at the top of
`BaseObservable.__get__`:

```python
if instance is None:
    return self
```

This is the same convention `property` follows. `Observable` inherits this
`__get__`, so the single guard covers both classes. Instance access is unchanged.

## Test

Added `test_observable_class_level_access`: class-level access returns the
`Observable` descriptor, `hasattr(cls, name)` is `True`, and instance access
still returns the value.

mesa_signals tests pass under `-Werror`; ruff clean.
