### PR TITLE
fix: return descriptor on class-level Observable access (#3732)

### DIFF
--- a/mesa/experimental/mesa_signals/core.py
+++ b/mesa/experimental/mesa_signals/core.py
@@ -64,6 +64,10 @@ class BaseObservable:
         self.fallback_value = fallback_value
 
     def __get__(self, instance: HasEmitters, owner):  # noqa: D105
+        if instance is None:
+            # class-level access (``Cls.attr``) returns the descriptor itself,
+            # matching ``property`` and the standard descriptor protocol
+            return self
         value = getattr(instance, self.private_name)
 
         if CURRENT_COMPUTED is not None:

--- a/tests/experimental/test_mesa_signals.py
+++ b/tests/experimental/test_mesa_signals.py
@@ -42,6 +42,37 @@ def test_observables():
     handler.assert_called_once()
 
 
+def test_observable_class_level_access():
+    """Observables follow the descriptor protocol on class-level access.
+
+    Accessing an Observable/ObservableList on the class rather than an
+    instance should return the descriptor itself, like ``property``, instead
+    of raising ``AttributeError`` (gh #3732).
+    """
+
+    class MyAgent(Agent, HasEmitters):
+        value = Observable()
+        items = ObservableList()
+
+        def __init__(self, model):
+            super().__init__(model)
+            self.value = 10
+
+    model = Model(rng=42)
+    agent = MyAgent(model)
+
+    # instance access is unchanged
+    assert agent.value == 10
+
+    # class-level access returns the descriptor (was AttributeError)
+    assert isinstance(MyAgent.value, Observable)
+    assert isinstance(MyAgent.items, ObservableList)
+
+    # hasattr no longer silently swallows the AttributeError
+    assert hasattr(MyAgent, "value")
+    assert hasattr(MyAgent, "items")
+
+
 def test_HasEmitters():
     """Test Observable."""
 


### PR DESCRIPTION
Fixes #3732.

`BaseObservable.__get__` calls `getattr(instance, self.private_name)` unconditionally. On class-level access (e.g. `MyAgent.value`) Python calls `__get__` with `instance=None`, so this becomes `getattr(None, "_value")` and raises `AttributeError` instead of returning the descriptor. As a side effect `hasattr(MyAgent, "value")` silently returns `False`, even though every instance has the attribute.

Standard descriptors (including the built-in `property`) return the descriptor itself when `instance is None`. This adds that guard at the top of `BaseObservable.__get__`:

```python
class MyAgent(Agent, HasEmitters):
    value = Observable()

MyAgent.value               # before: AttributeError -> after: the Observable descriptor
hasattr(MyAgent, "value")   # before: False -> after: True
```

`Observable` and `ObservableList` both inherit this `__get__` (neither overrides it), so the single base-class guard fixes class-level access for all observable descriptors at once.

Added `test_observable_class_level_access`, which checks class-level access and `hasattr` for both `Observable` and `ObservableList`. It fails on `main` (the `AttributeError`) and passes here, and the rest of `test_mesa_signals.py` stays green.

Thanks to @AshNicolus for the clear report and diagnosis.
