### PR TITLE
docs: show only stable version in switcher

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,7 +1,12 @@
 [
     {
-    "name": "stable",
-    "version": "stable",
-    "url": "https://mesa.readthedocs.io/en/stable/"
-  }
+        "name": "latest",
+        "version": "latest",
+        "url": "https://mesa.readthedocs.io/en/latest/"
+    },
+    {
+        "name": "v3.5.1",
+        "version": "v3.5.1",
+        "url": "https://mesa.readthedocs.io/en/v3.5.1/"
+    }
 ]

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -3,21 +3,5 @@
     "name": "stable",
     "version": "stable",
     "url": "https://mesa.readthedocs.io/en/stable/"
-  },
-  {
-    "name": "latest",
-    "version": "latest",
-    "url": "https://mesa.readthedocs.io/en/latest/"
-  },
-  {
-    "name": "2.4.0",
-    "version": "v2.4.0",
-    "url": "https://mesa.readthedocs.io/en/v2.4.0/"
-  },
-  {
-    "name": "3.5.1",
-    "version": "v3.5.1",
-    "url": "https://mesa.readthedocs.io/en/v3.5.1/"
-  },
-
+  }
 ]

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -7,6 +7,6 @@
     {
         "name": "v3.5.1",
         "version": "v3.5.1",
-        "url": "https://mesa.readthedocs.io/en/v3.5.1/"
+        "url": "https://mesa.readthedocs.io/v3.5.1/"
     }
 ]


### PR DESCRIPTION
This PR is for the docs to point only to the stable version present in mesa currently that is this one https://mesa.readthedocs.io/stable/ only and all other versions are removed as it the docs will guide to the only to the stable version as recommended by @tpike3 so i have removed all other version from docs/_static/switcher.json and used only the stable version. I think this solves the problem