### PR TITLE
fixing the version switcher in the docs

### DIFF
--- a/.github/workflows/update-switcher.yml
+++ b/.github/workflows/update-switcher.yml
@@ -1,0 +1,42 @@
+name: Update docs version switcher
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-switcher:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+      - name: Update switcher.json
+        shell: python
+        env:
+          NEW_TAG: ${{ github.ref_name }}
+        run: |
+          import json, os
+          from pathlib import Path
+          tag = os.environ["NEW_TAG"]
+          path = Path("docs/_static/switcher.json")
+          entries = json.loads(path.read_text())
+          if not any(e.get("version") == tag for e in entries):
+              entries.append({"name": tag, "version": tag, "url": f"https://mesa.readthedocs.io/{tag}/"})
+          path.write_text(json.dumps(entries, indent=2) + "\n")
+      - name: Open PR
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "docs: add ${{ github.ref_name }} to version switcher"
+          branch: "docs/switcher-${{ github.ref_name }}"
+          delete-branch: true
+          title: "docs: add ${{ github.ref_name }} to version switcher"
+          body: "Adds `${{ github.ref_name }}` to `docs/_static/switcher.json`."
+          base: main
+          labels: documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -309,7 +309,7 @@ To create a new release, follow these steps:
 4. Use the _Generate release notes_ button to automatically create release notes. Review them carefully for accuracy, and update labels and edit PR titles if necessary (step 1).
 5. Write a _Highlights_ section summarizing the most important features or changes in this release.
 6. Copy the release notes and save them by clicking the grey _Save draft_ button.
-7. Open a new PR to update the version number in [`mesa/__init__.py`](https://github.com/mesa/mesa/blob/main/mesa/__init__.py) and add the copied release notes to the [`HISTORY.md`](https://github.com/mesa/mesa/blob/main/HISTORY.md). For stable releases, also update [`docs/_static/switcher.json`](https://github.com/mesa/mesa/blob/main/docs/_static/switcher.json): add the new version and remove any older patch releases for the same minor version.
+7. Open a new PR to update the version number in [`mesa/__init__.py`](https://github.com/mesa/mesa/blob/main/mesa/__init__.py) and add the copied release notes to the [`HISTORY.md`](https://github.com/mesa/mesa/blob/main/HISTORY.md). For stable releases, `docs/_static/switcher.json` is updated automatically when the release tag is pushed.
 8. Once this PR is merged, return to the _Releases_ section and publish the draft release.
 9. The [`release.yml`](https://github.com/mesa/mesa/blob/main/.github/workflows/release.yml) CI workflow should automatically create and upload the package to PyPI. Verify this on [PyPI.org](https://pypi.org/project/mesa/).
 10. Finally, after release, open a new PR to update the version number in [`mesa/__init__.py`](https://github.com/mesa/mesa/blob/main/mesa/__init__.py) for the next release (e.g., `"3.1.0.dev"`).

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,7 +1,12 @@
 [
     {
-    "name": "stable",
-    "version": "stable",
-    "url": "https://mesa.readthedocs.io/en/stable/"
-  }
+        "name": "latest",
+        "version": "latest",
+        "url": "https://mesa.readthedocs.io/en/latest/"
+    },
+    {
+        "name": "v3.5.1",
+        "version": "v3.5.1",
+        "url": "https://mesa.readthedocs.io/en/v3.5.1/"
+    }
 ]

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -3,21 +3,5 @@
     "name": "stable",
     "version": "stable",
     "url": "https://mesa.readthedocs.io/en/stable/"
-  },
-  {
-    "name": "latest",
-    "version": "latest",
-    "url": "https://mesa.readthedocs.io/en/latest/"
-  },
-  {
-    "name": "2.4.0",
-    "version": "v2.4.0",
-    "url": "https://mesa.readthedocs.io/en/v2.4.0/"
-  },
-  {
-    "name": "3.5.1",
-    "version": "v3.5.1",
-    "url": "https://mesa.readthedocs.io/en/v3.5.1/"
-  },
-
+  }
 ]

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -2,7 +2,7 @@
     {
         "name": "latest",
         "version": "latest",
-        "url": "https://mesa.readthedocs.io/en/latest/"
+        "url": "https://mesa.readthedocs.io/latest/"
     },
     {
         "name": "v3.5.1",

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -7,6 +7,6 @@
     {
         "name": "v3.5.1",
         "version": "v3.5.1",
-        "url": "https://mesa.readthedocs.io/en/v3.5.1/"
+        "url": "https://mesa.readthedocs.io/v3.5.1/"
     }
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,7 +123,9 @@ nb_execution_raise_on_error = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = "pydata_sphinx_theme"
-
+version_match = os.environ.get("READTHEDOCS_VERSION", release)
+if not version_match or version_match.isdigit():
+    version_match = "latest"
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
@@ -131,7 +133,7 @@ html_theme_options = {
     "navbar_start": ["navbar-logo", "version-switcher"],
     "switcher": {
         "json_url": "https://mesa.readthedocs.io/latest/_static/switcher.json",
-        "version_match": os.environ.get("READTHEDOCS_VERSION", release),
+        "version_match": version_match,
     },
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,7 +130,7 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "navbar_start": ["navbar-logo", "version-switcher"],
     "switcher": {
-        "json_url": "https://mesa.readthedocs.io/stable/_static/switcher.json",
+        "json_url": "https://mesa.readthedocs.io/latest/_static/switcher.json",
         "version_match": os.environ.get("READTHEDOCS_VERSION", release),
     },
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,7 +130,7 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "navbar_start": ["navbar-logo", "version-switcher"],
     "switcher": {
-        "json_url": "https://mesa.readthedocs.io/en/stable/_static/switcher.json",
+        "json_url": "https://mesa.readthedocs.io/stable/_static/switcher.json",
         "version_match": os.environ.get("READTHEDOCS_VERSION", release),
     },
 }


### PR DESCRIPTION
this actually fix the version switcher in the read the docs , confy.py in docs folder actually generates the docs and in the switcher json link it previously has /en which was creating the problem so its a fix to that problem and followed up by #3738
