### PR TITLE
Remove unused assignments in test_copying_discrete_spaces

### DIFF
--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -1103,9 +1103,6 @@ def test_copying_discrete_spaces():  # noqa: D103
         grid = OrthogonalMooreGrid((100, 100), random=random.Random(42))
         grid_copy = copy.deepcopy(grid)
 
-        c1 = grid[(5, 5)].connections
-        c2 = grid_copy[(5, 5)].connections
-
         for c1, c2 in zip(grid.all_cells, grid_copy.all_cells):
             for k, v in c1.connections.items():
                 assert v.coordinate == c2.connections[k].coordinate
@@ -1123,9 +1120,6 @@ def test_copying_discrete_spaces():  # noqa: D103
 
         grid = HexGrid((100, 100), random=random.Random(42))
         grid_copy = copy.deepcopy(grid)
-
-        c1 = grid[(5, 5)].connections
-        c2 = grid_copy[(5, 5)].connections
 
         for c1, c2 in zip(grid.all_cells, grid_copy.all_cells):
             for k, v in c1.connections.items():


### PR DESCRIPTION
## Description

Fixes #3737

The variables `c1` and `c2` in `test_copying_discrete_spaces` were assigned before the loop but immediately shadowed by the loop variables:

```python
c1 = grid[(5, 5)].connections
c2 = grid_copy[(5, 5)].connections

for c1, c2 in zip(grid.all_cells, grid_copy.all_cells):
```

As noted in the issue discussion, these assignments were never used because the loop iterates over all cells, including `(5, 5)`.

This PR removes the unused assignments from the `OrthogonalMooreGrid` and `HexGrid` test blocks, eliminating dead code without changing test behavior.

Kindly have a look at this, and if anything has to be changed do let me know, after the merging I will close #3737
