### PR TITLE
Fix broken file links in boid_flockers example.

### DIFF
--- a/mesa/examples/basic/boid_flockers/Readme.md
+++ b/mesa/examples/basic/boid_flockers/Readme.md
@@ -21,9 +21,9 @@ Open the displayed local URL in your browser.
 
 ## Files
 
-* [model.py](model.py): Contains the Boid Model
-* [agents.py](agents.py): Contains the Boid agent
-* [app.py](app.py): Solara based Visualization code.
+* [model.py](https://github.com/projectmesa/mesa/blob/main/mesa/examples/basic/boid_flockers/model.py): Contains the Boid Model
+* [agents.py](https://github.com/projectmesa/mesa/blob/main/mesa/examples/basic/boid_flockers/agents.py): Contains the Boid agent
+* [app.py](https://github.com/projectmesa/mesa/blob/main/mesa/examples/basic/boid_flockers/app.py): Solara based Visualization code.
 
 ## Further Reading
 


### PR DESCRIPTION
Fix broken file links in boid_flockers example documentation.

The file list in the boid_flockers example page was displaying model.py, agents.py and app.py as non functional relative links.

The PR replaces those with working GitHub URLs pointing to the correct source files in the repository.