### PR TITLE
fix: add nest_asyncio to dev dependencies

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,7 +1,12 @@
 [
     {
-    "name": "stable",
-    "version": "stable",
-    "url": "https://mesa.readthedocs.io/en/stable/"
-  }
+        "name": "latest",
+        "version": "latest",
+        "url": "https://mesa.readthedocs.io/en/latest/"
+    },
+    {
+        "name": "v3.5.1",
+        "version": "v3.5.1",
+        "url": "https://mesa.readthedocs.io/en/v3.5.1/"
+    }
 ]

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -3,21 +3,5 @@
     "name": "stable",
     "version": "stable",
     "url": "https://mesa.readthedocs.io/en/stable/"
-  },
-  {
-    "name": "latest",
-    "version": "latest",
-    "url": "https://mesa.readthedocs.io/en/latest/"
-  },
-  {
-    "name": "2.4.0",
-    "version": "v2.4.0",
-    "url": "https://mesa.readthedocs.io/en/v2.4.0/"
-  },
-  {
-    "name": "3.5.1",
-    "version": "v3.5.1",
-    "url": "https://mesa.readthedocs.io/en/v3.5.1/"
-  },
-
+  }
 ]

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -2,7 +2,7 @@
     {
         "name": "latest",
         "version": "latest",
-        "url": "https://mesa.readthedocs.io/en/latest/"
+        "url": "https://mesa.readthedocs.io/latest/"
     },
     {
         "name": "v3.5.1",

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -7,6 +7,6 @@
     {
         "name": "v3.5.1",
         "version": "v3.5.1",
-        "url": "https://mesa.readthedocs.io/en/v3.5.1/"
+        "url": "https://mesa.readthedocs.io/v3.5.1/"
     }
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,7 +130,7 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "navbar_start": ["navbar-logo", "version-switcher"],
     "switcher": {
-        "json_url": "https://mesa.readthedocs.io/stable/_static/switcher.json",
+        "json_url": "https://mesa.readthedocs.io/latest/_static/switcher.json",
         "version_match": os.environ.get("READTHEDOCS_VERSION", release),
     },
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,7 +130,7 @@ html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "navbar_start": ["navbar-logo", "version-switcher"],
     "switcher": {
-        "json_url": "https://mesa.readthedocs.io/en/stable/_static/switcher.json",
+        "json_url": "https://mesa.readthedocs.io/stable/_static/switcher.json",
         "version_match": os.environ.get("READTHEDOCS_VERSION", release),
     },
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ examples = [
 ]
 docs = [
   "mesa[rec]",
+  "nest_asyncio",
   "sphinx",
   "ipython",
   "pydata_sphinx_theme",


### PR DESCRIPTION
**Problem**
CI is failing on Python 3.13 with:`ModuleNotFoundError: No module named 'nest_asyncio'`
**Fix**
Adding it explicitly to Mesa's dev dependenicy as a workaround until it's fixed upstream in `ipyvuetify`.

closes #3751 