### PR TITLE
Add a RunConfiguration class for parameter sweeps

### DIFF
--- a/docs/apis/experimental.md
+++ b/docs/apis/experimental.md
@@ -33,6 +33,6 @@ This namespace contains experimental features. These are under development, and 
 ```
 
 ```{eval-rst}
-.. automodule:: experimental.scenarios.model_with_scenario
+.. automodule:: experimental.scenarios.runner
    :members:
 ```

--- a/mesa/experimental/scenarios/__init__.py
+++ b/mesa/experimental/scenarios/__init__.py
@@ -1,7 +1,7 @@
 """Scenarios module."""
 
-from .scenario import Scenario
 from .runner import RunConfiguration
+from .scenario import Scenario
 
 __all__ = [
     "Scenario",

--- a/mesa/experimental/scenarios/__init__.py
+++ b/mesa/experimental/scenarios/__init__.py
@@ -3,7 +3,4 @@
 from .runner import RunConfiguration
 from .scenario import Scenario
 
-__all__ = [
-    "RunConfiguration",
-    "Scenario"
-]
+__all__ = ["RunConfiguration", "Scenario"]

--- a/mesa/experimental/scenarios/__init__.py
+++ b/mesa/experimental/scenarios/__init__.py
@@ -1,6 +1,7 @@
 """Scenarios module."""
 
 from .scenario import Scenario
+from .runner import RunConfiguration
 
 __all__ = [
     "Scenario",

--- a/mesa/experimental/scenarios/__init__.py
+++ b/mesa/experimental/scenarios/__init__.py
@@ -1,8 +1,9 @@
 """Scenarios module."""
 
-from .scenario import Scenario
 from .runner import RunConfiguration
+from .scenario import Scenario
 
 __all__ = [
-    "Scenario",
+    "RunConfiguration",
+    "Scenario"
 ]

--- a/mesa/experimental/scenarios/runner.py
+++ b/mesa/experimental/scenarios/runner.py
@@ -1,0 +1,78 @@
+"""Classes for running parameter sweeps over scenarios."""
+from typing import Any
+
+import pandas as pd
+
+from mesa import Model
+from mesa.experimental.scenarios import Scenario
+
+
+class RunConfiguration:
+    """Defines how a single Scenario is executed and what is extracted from it.
+
+    Can be used as is for simple use cases or subclassed by overriding one or more of the following
+    methods
+
+    - ``instantiate_model`` — construct a Model from a Scenario (default:
+      ``model_class(*model_args, scenario=scenario, *model_kwargs)``).
+    - ``run_model`` — advance the model. Default delegates to ``model.run_until`` based on the ``until`` attribute.
+      Override for alternative run control
+    - ``extract_output`` — return a dict with outcome names as key and dataframes as values
+
+    Stopping is the model's responsibility. ``RunConfiguration`` only chooses
+    which run primitive to call.
+
+    """
+    def __init__(self, model_class: type[Model], until:float | int, model_args:None| list[Any]=None,
+                 model_kwargs:None|dict[str, Any]=None, outcomes: None|str|list[str]=None):
+        """Initialize a RunConfiguration object.
+
+        Args:
+            model_class: the model class to instantiate
+            until: until which time to run the model
+            model_args: any additional model arguments
+            model_kwargs: any additional model keyword arguments
+            outcomes: the outcomes to extract. If None, extract all outcomes.
+        """
+        super().__init__()
+
+        if not (isinstance(model_class, type) and issubclass(model_class, Model)):
+            raise TypeError("model_class must be a subclass of Model")
+        if not isinstance(until, (int, float)):
+            raise TypeError("until must be an int or float")
+        if until<=0:
+            raise ValueError("until must be positive")
+
+        self.model_class = model_class
+        self.model_args = [] if model_args is None else model_args
+        self.model_kwargs = {} if model_kwargs is None else model_kwargs
+        self.until = until
+
+        if isinstance(outcomes, str):
+            outcomes = [outcomes]
+        self.outcomes = outcomes
+
+    def instantiate_model(self, scenario) -> Model:
+        """Instantiate the model."""
+        return self.model_class(*self.model_args, scenario=scenario, **self.model_kwargs)
+
+    def run_model(self, model: Model):
+        """Run the model."""
+        model.run_until(self.until)
+
+    def extract_output(self, model: Model) -> dict[str, pd.DataFrame]:
+        """Extract output from model."""
+        # fixme:: this code assumed that the recorder is assigned to model.data_recorder
+        #   this is probably a a convention that needs to be pinned down explicitly on the model class
+        if self.outcomes is None:
+            return model.data_recorder.get_all_dataframes()
+        else:
+            return {k:model.data_recorder.get_table_dataframe(k) for k in self.outcomes}
+
+    def __call__(self, scenario: Scenario) -> dict[str, pd.DataFrame]:
+        """Run the scenario and extract output."""
+        model = self.instantiate_model(scenario)
+        self.run_model(model)
+        output = self.extract_output(model)
+        return output
+

--- a/mesa/experimental/scenarios/runner.py
+++ b/mesa/experimental/scenarios/runner.py
@@ -1,10 +1,14 @@
 """Classes for running parameter sweeps over scenarios."""
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
-from mesa import Model
 from mesa.experimental.scenarios import Scenario
+
+if TYPE_CHECKING:
+    from mesa.model import Model
 
 
 class RunConfiguration:
@@ -24,7 +28,7 @@ class RunConfiguration:
 
     """
     def __init__(self, model_class: type[Model], until:float | int, model_args:None| list[Any]=None,
-                 model_kwargs:None|dict[str, Any]=None, outcomes: None|str|list[str]=None):
+                 model_kwargs:None|dict[str, Any]=None, outcomes: None|str|list[str]=None, data_recorder_attr_name="data_recorder"):
         """Initialize a RunConfiguration object.
 
         Args:
@@ -33,9 +37,12 @@ class RunConfiguration:
             model_args: any additional model arguments
             model_kwargs: any additional model keyword arguments
             outcomes: the outcomes to extract. If None, extract all outcomes.
+            data_recorder_attr_name : the name of the data recorder attribute to use on the model
         """
         super().__init__()
 
+        # we need to avoid circular imports
+        from mesa.model import Model  # noqa: PLC0415
         if not (isinstance(model_class, type) and issubclass(model_class, Model)):
             raise TypeError("model_class must be a subclass of Model")
         if not isinstance(until, (int, float)):
@@ -47,6 +54,10 @@ class RunConfiguration:
         self.model_args = [] if model_args is None else model_args
         self.model_kwargs = {} if model_kwargs is None else model_kwargs
         self.until = until
+
+        # fixme:: this code leaves it to the user to set the attribute to which the recorder is assigned
+        #   this is probably a a convention that needs to be pinned down explicitly on the model class
+        self.data_recorder_attr_name = data_recorder_attr_name
 
         if isinstance(outcomes, str):
             outcomes = [outcomes]
@@ -62,12 +73,12 @@ class RunConfiguration:
 
     def extract_output(self, model: Model) -> dict[str, pd.DataFrame]:
         """Extract output from model."""
-        # fixme:: this code assumed that the recorder is assigned to model.data_recorder
-        #   this is probably a a convention that needs to be pinned down explicitly on the model class
+        recorder = getattr(model, self.data_recorder_attr_name)
+
         if self.outcomes is None:
-            return model.data_recorder.get_all_dataframes()
+            return recorder.get_all_dataframes()
         else:
-            return {k:model.data_recorder.get_table_dataframe(k) for k in self.outcomes}
+            return {k:recorder.get_table_dataframe(k) for k in self.outcomes}
 
     def __call__(self, scenario: Scenario) -> dict[str, pd.DataFrame]:
         """Run the scenario and extract output."""

--- a/mesa/experimental/scenarios/runner.py
+++ b/mesa/experimental/scenarios/runner.py
@@ -1,4 +1,5 @@
 """Classes for running parameter sweeps over scenarios."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
@@ -27,8 +28,16 @@ class RunConfiguration:
     which run primitive to call.
 
     """
-    def __init__(self, model_class: type[Model], until:float | int, model_args:None| list[Any]=None,
-                 model_kwargs:None|dict[str, Any]=None, outcomes: None|str|list[str]=None, data_recorder_attr_name="data_recorder"):
+
+    def __init__(
+        self,
+        model_class: type[Model],
+        until: float | int,
+        model_args: None | list[Any] = None,
+        model_kwargs: None | dict[str, Any] = None,
+        outcomes: None | str | list[str] = None,
+        data_recorder_attr_name="data_recorder",
+    ):
         """Initialize a RunConfiguration object.
 
         Args:
@@ -43,11 +52,12 @@ class RunConfiguration:
 
         # we need to avoid circular imports
         from mesa.model import Model  # noqa: PLC0415
+
         if not (isinstance(model_class, type) and issubclass(model_class, Model)):
             raise TypeError("model_class must be a subclass of Model")
         if not isinstance(until, (int, float)):
             raise TypeError("until must be an int or float")
-        if until<=0:
+        if until <= 0:
             raise ValueError("until must be positive")
 
         self.model_class = model_class
@@ -65,7 +75,9 @@ class RunConfiguration:
 
     def instantiate_model(self, scenario) -> Model:
         """Instantiate the model."""
-        return self.model_class(*self.model_args, scenario=scenario, **self.model_kwargs)
+        return self.model_class(
+            *self.model_args, scenario=scenario, **self.model_kwargs
+        )
 
     def run_model(self, model: Model):
         """Run the model."""
@@ -78,7 +90,7 @@ class RunConfiguration:
         if self.outcomes is None:
             return recorder.get_all_dataframes()
         else:
-            return {k:recorder.get_table_dataframe(k) for k in self.outcomes}
+            return {k: recorder.get_table_dataframe(k) for k in self.outcomes}
 
     def __call__(self, scenario: Scenario) -> dict[str, pd.DataFrame]:
         """Run the scenario and extract output."""
@@ -86,4 +98,3 @@ class RunConfiguration:
         self.run_model(model)
         output = self.extract_output(model)
         return output
-

--- a/mesa/experimental/scenarios/runner.py
+++ b/mesa/experimental/scenarios/runner.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
+from mesa.exceptions import MesaException
+
 if TYPE_CHECKING:
     from mesa.experimental.scenarios import Scenario
     from mesa.model import Model
@@ -18,7 +20,7 @@ class RunConfiguration:
     methods
 
     - ``instantiate_model`` — construct a Model from a Scenario (default:
-      ``model_class(*model_args, scenario=scenario, *model_kwargs)``).
+      ``model_class(*model_args, scenario=scenario, **model_kwargs)``).
     - ``run_model`` — advance the model. Default delegates to ``model.run_until`` based on the ``until`` attribute.
       Override for alternative run control
     - ``extract_output`` — return a dict with outcome names as key and dataframes as values
@@ -47,8 +49,6 @@ class RunConfiguration:
             outcomes: the outcomes to extract. If None, extract all outcomes.
             data_recorder_attr_name : the name of the data recorder attribute to use on the model
         """
-        super().__init__()
-
         # we need to avoid circular imports
         from mesa.model import Model  # noqa: PLC0415
 
@@ -74,11 +74,20 @@ class RunConfiguration:
 
     def instantiate_model(self, scenario: Scenario) -> Model:
         """Instantiate the model."""
-        return self.model_class(
-            *self.model_args, scenario=scenario, **self.model_kwargs
-        )
+        try:
+            return self.model_class(
+                *self.model_args, scenario=scenario, **self.model_kwargs
+            )
+        except Exception as e:
+            raise ModelInstantiationError(
+                f"Failed to instantiate {self.model_class.__name__} "
+                f"Please check your model_args and model_kwargs.\n"
+                f" - Passed args: {self.model_args}\n"
+                f" - Passed kwargs: {self.model_kwargs}\n"
+                f" - for scenario: {{'scenario': {scenario}}}\n"
+            ) from e
 
-    def run_model(self, model: Model):
+    def run_model(self, model: Model) -> None:
         """Run the model."""
         model.run_until(self.until)
 
@@ -97,3 +106,6 @@ class RunConfiguration:
         self.run_model(model)
         output = self.extract_output(model)
         return output
+
+class ModelInstantiationError(MesaException):
+  """Raised when a model cannot be instantiated for a scenario."""

--- a/mesa/experimental/scenarios/runner.py
+++ b/mesa/experimental/scenarios/runner.py
@@ -72,7 +72,7 @@ class RunConfiguration:
             outcomes = [outcomes]
         self.outcomes = outcomes
 
-    def instantiate_model(self, scenario:Scenario) -> Model:
+    def instantiate_model(self, scenario: Scenario) -> Model:
         """Instantiate the model."""
         return self.model_class(
             *self.model_args, scenario=scenario, **self.model_kwargs

--- a/mesa/experimental/scenarios/runner.py
+++ b/mesa/experimental/scenarios/runner.py
@@ -107,5 +107,6 @@ class RunConfiguration:
         output = self.extract_output(model)
         return output
 
+
 class ModelInstantiationError(MesaException):
-  """Raised when a model cannot be instantiated for a scenario."""
+    """Raised when a model cannot be instantiated for a scenario."""

--- a/mesa/experimental/scenarios/runner.py
+++ b/mesa/experimental/scenarios/runner.py
@@ -6,9 +6,8 @@ from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 
-from mesa.experimental.scenarios import Scenario
-
 if TYPE_CHECKING:
+    from mesa.experimental.scenarios import Scenario
     from mesa.model import Model
 
 
@@ -73,7 +72,7 @@ class RunConfiguration:
             outcomes = [outcomes]
         self.outcomes = outcomes
 
-    def instantiate_model(self, scenario) -> Model:
+    def instantiate_model(self, scenario:Scenario) -> Model:
         """Instantiate the model."""
         return self.model_class(
             *self.model_args, scenario=scenario, **self.model_kwargs

--- a/tests/experimental/test_scenarios.py
+++ b/tests/experimental/test_scenarios.py
@@ -1,13 +1,14 @@
 """Tests for mesa.experimental.scenarios."""
-
 import pickle
 
 import numpy as np
+import pandas as pd
 import pytest
 import scipy.stats.qmc as qmc
 
 from mesa import Agent, Model
-from mesa.experimental.scenarios import Scenario
+from mesa.experimental.data_collection import DataRecorder
+from mesa.experimental.scenarios import RunConfiguration, Scenario
 from mesa.experimental.scenarios.scenario import rescale_samples
 
 
@@ -331,3 +332,51 @@ def test_from_ndarray_returns_subclass():
     scenarios = MyScenario.from_ndarray(samples, ["x"], rng=42)
 
     assert isinstance(scenarios[0], MyScenario)
+
+
+def test_run_configuration(mocker):
+    """Tests for RunConfiguration."""
+    dummy_recorder = mocker.Mock(spec=DataRecorder)
+
+
+    class DummyModel(Model):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.data_recorder = dummy_recorder()
+
+            # setting up the mock
+            self.data_recorder.get_table_dataframe.return_value = pd.DataFrame()
+            self.data_recorder.get_all_dataframes.return_value = {"a": pd.DataFrame(), "b": pd.DataFrame()}
+
+    until = 10
+    configuration = RunConfiguration(DummyModel, until=until)
+    assert configuration.model_class is DummyModel
+
+    with pytest.raises(TypeError):
+        RunConfiguration(DummyModel(), until=until)
+    with pytest.raises(TypeError):
+        RunConfiguration(object, until=until)
+    with pytest.raises(TypeError):
+        RunConfiguration(DummyModel, until="some string")
+    with pytest.raises(ValueError):
+        RunConfiguration(DummyModel, until=-until)
+
+    configuration = RunConfiguration(DummyModel, until=until, outcomes="a")
+    assert configuration.outcomes == ["a"]
+
+    configuration = RunConfiguration(DummyModel, until=until)
+    scenario = Scenario()
+    model = configuration.instantiate_model(scenario)
+    assert model.scenario == scenario
+
+    configuration.run_model(model)
+    assert model.time == until
+
+    output = configuration.extract_output(model)
+    assert "a" in output
+    assert "b" in output
+
+    configuration = RunConfiguration(DummyModel, until=until, outcomes="a")
+    output = configuration(scenario)
+    assert "a" in output
+    assert "b" not in output

--- a/tests/experimental/test_scenarios.py
+++ b/tests/experimental/test_scenarios.py
@@ -1,4 +1,5 @@
 """Tests for mesa.experimental.scenarios."""
+
 import pickle
 
 import numpy as np
@@ -338,7 +339,6 @@ def test_run_configuration(mocker):
     """Tests for RunConfiguration."""
     dummy_recorder = mocker.Mock(spec=DataRecorder)
 
-
     class DummyModel(Model):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
@@ -346,7 +346,10 @@ def test_run_configuration(mocker):
 
             # setting up the mock
             self.data_recorder.get_table_dataframe.return_value = pd.DataFrame()
-            self.data_recorder.get_all_dataframes.return_value = {"a": pd.DataFrame(), "b": pd.DataFrame()}
+            self.data_recorder.get_all_dataframes.return_value = {
+                "a": pd.DataFrame(),
+                "b": pd.DataFrame(),
+            }
 
     until = 10
     configuration = RunConfiguration(DummyModel, until=until)


### PR DESCRIPTION
This PR adds a new `RunConfiguration` class. This class encapsulates the logic of instantiating a model, running it for a single scenario, and extracting user specifiable output from the run. This PR is part of the larger project of replacing the batch runner with a more flexible and powerful alternative. For detailed background, see #3483, and specifically https://github.com/mesa/mesa/discussions/3483#discussioncomment-17323416

The `RunConfiguration` class is designed to be subclassable, but it makes some default assumptions and provides keyword arguments to control its basic behavior to cover the most common use cases. 
* The class using `model.run_until` with a user specifiable end time
* It extracts all or the user specified output from the data_recorder. The attribute to which the recorder is assigned defaults to `data_recorder` but this is currently controllable via a keyword argument
* additional arguments and keyword arguments necessary to instantiate a model can also be passed to `RunConfiguration`. 

User subclassing can be done by overriding any of the three methods:
* `instantiate_model` - handles model instantiation
* `run_model` - handles running the model
* `extract_output` - handles the extraction and any post processing the user wants to do. 

It is likely that parts of this class will be refined in future PRs. Most notably, extract_output is currently a basic implementation which is likely to be expanded when working out the storage solution for parameter sweeps. 