### PR TITLE
Added __repr__ method to Agent class

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -205,9 +205,9 @@ class Agent[M: Model]:
 
         return AgentSet(agents, random=model.random)
 
-    def __str__(self) -> str:
-        """Return a human-readable string representation of the agent."""
-        return f"{self.__class__.__name__}, agent_id = {self.unique_id}"
+    def __repr__(self) -> str:
+        """Return an unambiguous string representation of the agent."""
+        return f"{self.__class__.__name__}(unique_id={self.unique_id})"
 
     @property
     def random(self) -> Random:

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -205,6 +205,10 @@ class Agent[M: Model]:
 
         return AgentSet(agents, random=model.random)
 
+    def __str__(self) -> str:
+        """Return a human-readable string representation of the agent."""
+        return f"{self.__class__.__name__}, agent_id = {self.unique_id}"
+
     def __repr__(self) -> str:
         """Return an unambiguous string representation of the agent."""
         return f"{self.__class__.__name__}(unique_id={self.unique_id})"

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -37,7 +37,7 @@ class Agent[M: Model]:
     """
 
     _datasets: ClassVar = set()
-    _repr_excluded_fields = {"model", "current_action"}
+    _repr_excluded_fields: ClassVar[set[str]] = {"model", "current_action"}
 
     def __init_subclass__(cls, **kwargs):
         """Called when DatasetTrackedAgent is subclassed."""

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -212,21 +212,22 @@ class Agent[M: Model]:
     def __repr__(self) -> str:
         """Return an unambiguous string representation including agent state."""
         # Mesa default fields to exclude
-        mesa_fields = {'model', 'unique_id', 'current_action'}
-        
+        mesa_fields = {"model", "unique_id", "current_action"}
+
         # Get user-defined attributes (exclude private and Mesa fields)
         user_attrs = {
-            k: v for k, v in self.__dict__.items()
-            if not k.startswith('_') and k not in mesa_fields
+            k: v
+            for k, v in self.__dict__.items()
+            if not k.startswith("_") and k not in mesa_fields
         }
-        
+
         # Build the repr string
         if user_attrs:
             attr_str = ", ".join(f"{k}={v!r}" for k, v in user_attrs.items())
             return f"<{self.__class__.__name__} id={self.unique_id} {attr_str}>"
         else:
             return f"<{self.__class__.__name__} id={self.unique_id}>"
-    
+
     @property
     def random(self) -> Random:
         """Return a seeded stdlib rng."""

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -210,9 +210,23 @@ class Agent[M: Model]:
         return f"{self.__class__.__name__}, agent_id = {self.unique_id}"
 
     def __repr__(self) -> str:
-        """Return an unambiguous string representation of the agent."""
-        return f"{self.__class__.__name__}(unique_id={self.unique_id})"
-
+        """Return an unambiguous string representation including agent state."""
+        # Mesa default fields to exclude
+        mesa_fields = {'model', 'unique_id', 'current_action'}
+        
+        # Get user-defined attributes (exclude private and Mesa fields)
+        user_attrs = {
+            k: v for k, v in self.__dict__.items()
+            if not k.startswith('_') and k not in mesa_fields
+        }
+        
+        # Build the repr string
+        if user_attrs:
+            attr_str = ", ".join(f"{k}={v!r}" for k, v in user_attrs.items())
+            return f"<{self.__class__.__name__} id={self.unique_id} {attr_str}>"
+        else:
+            return f"<{self.__class__.__name__} id={self.unique_id}>"
+    
     @property
     def random(self) -> Random:
         """Return a seeded stdlib rng."""

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -37,6 +37,7 @@ class Agent[M: Model]:
     """
 
     _datasets: ClassVar = set()
+    _repr_excluded_fields = {"model", "current_action"}
 
     def __init_subclass__(cls, **kwargs):
         """Called when DatasetTrackedAgent is subclassed."""
@@ -211,17 +212,16 @@ class Agent[M: Model]:
 
     def __repr__(self) -> str:
         """Return an unambiguous string representation including agent state."""
-        # Mesa default fields to exclude
-        mesa_fields = {"model", "unique_id", "current_action"}
+        # Get excluded fields (allows subclasses to override)
+        excluded = self._repr_excluded_fields
 
         # Get user-defined attributes (exclude private and Mesa fields)
         user_attrs = {
             k: v
             for k, v in self.__dict__.items()
-            if not k.startswith("_") and k not in mesa_fields
+            if not k.startswith("_") and k not in excluded
         }
 
-        # Build the repr string
         if user_attrs:
             attr_str = ", ".join(f"{k}={v!r}" for k, v in user_attrs.items())
             return f"<{self.__class__.__name__} id={self.unique_id} {attr_str}>"

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -169,6 +169,7 @@ def test_agent_str():
     agent = AgentTest(model)
     assert str(agent) == f"AgentTest, agent_id = {agent.unique_id}"
 
+
 def test_agent_repr():
     """Test __repr__ returns unambiguous string."""
     model = Model()
@@ -180,8 +181,10 @@ def test_agent_repr():
     assert str(agent.unique_id) in r
     assert "object at 0x" not in r
 
+
 def test_agent_repr_subclass():
     """Test __repr__ uses subclass name, not base Agent name."""
+
     class Wolf(Agent):
         pass
 

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -168,3 +168,28 @@ def test_agent_str():
     model = Model()
     agent = AgentTest(model)
     assert str(agent) == f"AgentTest, agent_id = {agent.unique_id}"
+
+def test_agent_repr():
+    """Test __repr__ returns unambiguous string."""
+    model = Model()
+    agent = AgentTest(model)
+
+    r = repr(agent)
+
+    assert "AgentTest" in r
+    assert str(agent.unique_id) in r
+    assert "object at 0x" not in r
+
+def test_agent_repr_subclass():
+    """Test __repr__ uses subclass name, not base Agent name."""
+    class Wolf(Agent):
+        pass
+
+    model = Model()
+    wolf = Wolf(model)
+
+    r = repr(wolf)
+
+    assert "Wolf" in r
+    assert str(wolf.unique_id) in r
+    assert "Agent" not in r

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -172,6 +172,7 @@ def test_agent_str():
 
 def test_agent_repr():
     """Test __repr__ returns unambiguous string with agent state."""
+
     class Wolf(Agent):
         def __init__(self, model):
             super().__init__(model)
@@ -190,6 +191,7 @@ def test_agent_repr():
     assert "energy=50" in r
     assert "object at 0x" not in r  # no fallback to object repr
 
+
 def test_agent_repr_basic():
     """Test __repr__ on basic Agent with no custom attributes."""
     model = Model()
@@ -202,6 +204,7 @@ def test_agent_repr_basic():
     # Should NOT have extra stuff if no custom attrs
     assert "model=" not in r  # model is filtered out
     assert "_" not in r  # no private attrs
+
 
 def test_agent_repr_subclass():
     """Test __repr__ uses subclass name, not base Agent name."""

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -171,16 +171,37 @@ def test_agent_str():
 
 
 def test_agent_repr():
-    """Test __repr__ returns unambiguous string."""
+    """Test __repr__ returns unambiguous string with agent state."""
+    class Wolf(Agent):
+        def __init__(self, model):
+            super().__init__(model)
+            self.wealth = 100
+            self.energy = 50
+
     model = Model()
-    agent = AgentTest(model)
+    wolf = Wolf(model)
+
+    r = repr(wolf)
+
+    # Check it shows class name, id, and state
+    assert "Wolf" in r
+    assert "id=0" in r or "id=" in r  # unique_id is in repr
+    assert "wealth=100" in r
+    assert "energy=50" in r
+    assert "object at 0x" not in r  # no fallback to object repr
+
+def test_agent_repr_basic():
+    """Test __repr__ on basic Agent with no custom attributes."""
+    model = Model()
+    agent = Agent(model)
 
     r = repr(agent)
 
-    assert "AgentTest" in r
-    assert str(agent.unique_id) in r
-    assert "object at 0x" not in r
-
+    assert "Agent" in r
+    assert "id=" in r
+    # Should NOT have extra stuff if no custom attrs
+    assert "model=" not in r  # model is filtered out
+    assert "_" not in r  # no private attrs
 
 def test_agent_repr_subclass():
     """Test __repr__ uses subclass name, not base Agent name."""

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -245,3 +245,61 @@ def test_agent_repr_extensible():
     assert "wealth=100" in r
     assert "internal_cache" not in r
     assert "secret_data" not in r
+
+
+def test_agent_repr_filters_mesa_fields():
+    """Test that Mesa internal fields are filtered from __repr__."""
+    class Wolf(Agent):
+        def __init__(self, model):
+            super().__init__(model)
+            self.wealth = 100
+            self.model = model  
+            self.current_action = None 
+
+    model = Model()
+    wolf = Wolf(model)
+
+    r = repr(wolf)
+
+    assert "wealth=100" in r
+    assert "model=" not in r
+    assert "current_action=" not in r
+
+def test_agent_repr_filters_private_attributes():
+    """Test that private attributes (starting with _) are filtered from __repr__."""
+    class Wolf(Agent):
+        def __init__(self, model):
+            super().__init__(model)
+            self.wealth = 100
+            self._internal_state = "processing"
+            self._cache = {"data": "sensitive"}
+
+    model = Model()
+    wolf = Wolf(model)
+
+    r = repr(wolf)
+
+    assert "wealth=100" in r
+    assert "_internal_state" not in r
+    assert "_cache" not in r
+    assert "processing" not in r
+
+def test_agent_repr_with_various_types():
+    """Test __repr__ with different attribute types (strings, numbers, None, lists)."""
+    class Wolf(Agent):
+        def __init__(self, model):
+            super().__init__(model)
+            self.name = "Alpha"
+            self.count = 42
+            self.status = None
+            self.items = [1, 2, 3]
+
+    model = Model()
+    wolf = Wolf(model)
+
+    r = repr(wolf)
+
+    assert "name='Alpha'" in r or 'name="Alpha"' in r
+    assert "count=42" in r
+    assert "status=None" in r
+    assert "items=[1, 2, 3]" in r

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,5 +1,7 @@
 """Agent.py related tests."""
 
+from typing import ClassVar
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -224,7 +226,11 @@ def test_agent_repr_extensible():
     """Test that subclasses can exclude additional fields from __repr__."""
 
     class Wolf(Agent):
-        _repr_excluded_fields = {"model", "current_action", "internal_cache"}
+        _repr_excluded_fields: ClassVar[set[str]] = {
+            "model",
+            "current_action",
+            "internal_cache",
+        }
 
         def __init__(self, model):
             super().__init__(model)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -184,12 +184,11 @@ def test_agent_repr():
 
     r = repr(wolf)
 
-    # Check it shows class name, id, and state
     assert "Wolf" in r
-    assert "id=0" in r or "id=" in r  # unique_id is in repr
+    assert "id=0" in r or "id=" in r
     assert "wealth=100" in r
     assert "energy=50" in r
-    assert "object at 0x" not in r  # no fallback to object repr
+    assert "object at 0x" not in r
 
 
 def test_agent_repr_basic():
@@ -201,9 +200,8 @@ def test_agent_repr_basic():
 
     assert "Agent" in r
     assert "id=" in r
-    # Should NOT have extra stuff if no custom attrs
-    assert "model=" not in r  # model is filtered out
-    assert "_" not in r  # no private attrs
+    assert "model=" not in r
+    assert "current_action=" not in r
 
 
 def test_agent_repr_subclass():
@@ -220,3 +218,24 @@ def test_agent_repr_subclass():
     assert "Wolf" in r
     assert str(wolf.unique_id) in r
     assert "Agent" not in r
+
+
+def test_agent_repr_extensible():
+    """Test that subclasses can exclude additional fields from __repr__."""
+
+    class Wolf(Agent):
+        _repr_excluded_fields = {"model", "current_action", "internal_cache"}
+
+        def __init__(self, model):
+            super().__init__(model)
+            self.wealth = 100
+            self.internal_cache = "secret_data"
+
+    model = Model()
+    wolf = Wolf(model)
+
+    r = repr(wolf)
+
+    assert "wealth=100" in r
+    assert "internal_cache" not in r
+    assert "secret_data" not in r

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -249,12 +249,13 @@ def test_agent_repr_extensible():
 
 def test_agent_repr_filters_mesa_fields():
     """Test that Mesa internal fields are filtered from __repr__."""
+
     class Wolf(Agent):
         def __init__(self, model):
             super().__init__(model)
             self.wealth = 100
-            self.model = model  
-            self.current_action = None 
+            self.model = model
+            self.current_action = None
 
     model = Model()
     wolf = Wolf(model)
@@ -265,8 +266,10 @@ def test_agent_repr_filters_mesa_fields():
     assert "model=" not in r
     assert "current_action=" not in r
 
+
 def test_agent_repr_filters_private_attributes():
     """Test that private attributes (starting with _) are filtered from __repr__."""
+
     class Wolf(Agent):
         def __init__(self, model):
             super().__init__(model)
@@ -284,8 +287,10 @@ def test_agent_repr_filters_private_attributes():
     assert "_cache" not in r
     assert "processing" not in r
 
+
 def test_agent_repr_with_various_types():
     """Test __repr__ with different attribute types (strings, numbers, None, lists)."""
+
     class Wolf(Agent):
         def __init__(self, model):
             super().__init__(model)


### PR DESCRIPTION
**Summary**
Adds `__repr__` method to the `Agent` class to provide meaningful string representations in debuggers, logs, and interactive shells.

**Problem**
The `Agent` class defined `__str__` but not `__repr__`, causing `repr(agent)` to fall back to `object.__repr__` which returns an unhelpful memory address that changes every run. This makes agents invisible in debuggers and logging output.

**Solution**
Implemented `__repr__` to return a descriptive string following the format: `ClassName(unique_id=<value>)`

**Consistency**
This change brings Agent in line with other core Mesa classes (EventList, Model, etc.) which already define __repr__. The pattern established in PR #2195 is now applied to Agent.

**Testing**
Added three new tests to verify:

test_agent_str(): Validates the existing __str__ method
test_agent_repr(): Validates the new __repr__ method
test_agent_repr_subclass(): Ensures __repr__ correctly uses the subclass name (e.g., Wolf not Agent)

**Fixes**
Closes #3758