### PR TITLE
Fix incorrect parameter documentation in VoronoiGrid

### DIFF
--- a/mesa/discrete_space/voronoi.py
+++ b/mesa/discrete_space/voronoi.py
@@ -197,10 +197,10 @@ class VoronoiGrid(DiscreteSpace):
 
         Args:
             centroids_coordinates: coordinates of centroids to build the tessellation space
-            capacity (int) : capacity of the cells in the discrete space
+            capacity (int | Callable): capacity of the cells in the discrete space, or a
+                callable computing the (int) capacity of a cell from its (float) polygon area
             random (Random): random number generator
             cell_klass (type[Cell]): type of cell class
-            capacity_function (Callable): function to compute (int) capacity according to (float) area
 
         """
         # Separate callable capacity from numeric capacity before passing to base class


### PR DESCRIPTION
**Summary**

The `VoronoiGrid.__init__` docstring (`mesa/discrete_space/voronoi.py`) documented a `capacity_function` parameter, but `capacity_function` is a local variable inside `__init__`, not an argument. The actual `capacity` parameter is typed `int | Callable | None` and already covers that behaviour.

This drops the nonexistent `capacity_function` entry and documents that `capacity` may be an int or a callable computing a cell's capacity from its polygon area.

Documentation-only change.
