### PR TITLE
Fix HexGrid neighbor offset selection for even/odd rows

### DIFF
--- a/mesa/discrete_space/grid.py
+++ b/mesa/discrete_space/grid.py
@@ -589,7 +589,7 @@ class HexGrid(Grid[T]):
 
         for cell in self.all_cells:
             i = cell.coordinate[1]
-            offsets = even_offsets if i % 2 else odd_offsets
+            offsets = odd_offsets if i % 2 else even_offsets
             self._connect_single_cell_2d(cell, offsets=offsets)
 
     def _connect_cells_nd(self) -> None:

--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -406,7 +406,7 @@ def test_cell_neighborhood():
     grid = HexGrid(
         (width, height), torus=False, capacity=None, random=random.Random(42)
     )
-    for radius, n in zip(range(1, 4), [3, 7, 13]):
+    for radius, n in zip(range(1, 4), [2, 6, 11]):
         if radius == 1:
             neighborhood = grid._cells[(0, 0)].neighborhood
         else:
@@ -418,7 +418,7 @@ def test_cell_neighborhood():
     grid = HexGrid(
         (width, height), torus=False, capacity=None, random=random.Random(42)
     )
-    for radius, n in zip(range(1, 4), [4, 10, 17]):
+    for radius, n in zip(range(1, 4), [4, 9, 15]):
         if radius == 1:
             neighborhood = grid._cells[(1, 0)].neighborhood
         else:
@@ -437,15 +437,15 @@ def test_hexgrid():
     assert len(grid._cells) == width * height
 
     # first row
-    assert len(grid._cells[(0, 0)].connections.values()) == 3
+    assert len(grid._cells[(0, 0)].connections.values()) == 2
     for connection in grid._cells[(0, 0)].connections.values():
-        assert connection.coordinate in {(0, 1), (1, 0), (1, 1)}
+        assert connection.coordinate in {(0, 1), (1, 0)}
 
     # second row
     assert len(grid._cells[(1, 0)].connections.values()) == 4
     for connection in grid._cells[(1, 0)].connections.values():
         # fmt: off
-        assert connection.coordinate in {   (1, 1), (2, 1),
+        assert connection.coordinate in {   (0, 1), (1, 1),
                                          (0, 0),    (2, 0),}
         # fmt: on
 
@@ -453,9 +453,9 @@ def test_hexgrid():
     assert len(grid._cells[(5, 5)].connections.values()) == 6
     for connection in grid._cells[(5, 5)].connections.values():
         # fmt: off
-        assert connection.coordinate in {  (4, 4), (5, 4),
+        assert connection.coordinate in {  (5, 4), (6, 4),
                                          (4, 5), (6, 5),
-                                         (4, 6), (5, 6)}
+                                         (5, 6), (6, 6)}
 
         # fmt: on
 
@@ -463,9 +463,9 @@ def test_hexgrid():
     assert len(grid._cells[(4, 4)].connections.values()) == 6
     for connection in grid._cells[(4, 4)].connections.values():
         # fmt: off
-        assert connection.coordinate in {(4, 3), (5, 3),
-                                         (3, 4), (5, 4),
-                                         (4, 5), (5, 5)}
+        assert connection.coordinate in {(3, 3), (4, 3),
+                                         (3, 4),    (5, 4),
+                                         (3, 5), (4, 5)}
 
         # fmt: on
 
@@ -476,11 +476,47 @@ def test_hexgrid():
     assert len(grid._cells[(0, 0)].connections.values()) == 6
     for connection in grid._cells[(0, 0)].connections.values():
         # fmt: off
-        assert connection.coordinate in {(0, 9), (1, 9),
+        assert connection.coordinate in {(0, 9), (9, 9),
                                          (9, 0), (1, 0),
-                                         (0, 1), (1, 1)}
+                                         (0, 1), (9, 1)}
 
         # fmt: on
+
+
+def _true_hex_neighbors(grid, coordinate):
+    """Nearest-neighbor coordinates derived from cell.position, independent of connections."""
+    width, height = grid.dimensions
+    width_px = width * np.sqrt(3)
+    height_px = height * 1.5
+    center = grid._cells[coordinate].position
+
+    def distance(other):
+        delta = other - center
+        if grid.torus:
+            delta[0] = (delta[0] + width_px / 2) % width_px - width_px / 2
+            delta[1] = (delta[1] + height_px / 2) % height_px - height_px / 2
+        return np.linalg.norm(delta)
+
+    distances = [
+        (round(distance(cell.position), 6), coord)
+        for coord, cell in grid._cells.items()
+        if coord != coordinate
+    ]
+    dmin = min(distances)[0]
+    return {coord for d, coord in distances if abs(d - dmin) < 1e-6}
+
+
+def test_hexgrid_connectivity_matches_geometry():
+    """HexGrid connections must match nearest neighbors by physical position."""
+    width = 10
+    height = 10
+
+    for torus in (False, True):
+        grid = HexGrid((width, height), torus=torus, random=random.Random(42))
+        for coordinate, cell in grid._cells.items():
+            actual = {connection.coordinate for connection in cell.connections.values()}
+            expected = _true_hex_neighbors(grid, coordinate)
+            assert actual == expected
 
 
 def test_networkgrid():


### PR DESCRIPTION
### Pre-PR Checklist
- [x] This PR is a bug fix, not a new feature or enhancement.

### Summary
`HexGrid._connect_cells_2d` picks the wrong offset table for every row (even and odd are swapped), so `cell.connections` disagrees with the true hexagonal neighbors implied by the grid's own physical-position geometry. This affects every cell in every `HexGrid`.

### Bug / Issue
No existing issue for this one. I found it while reading through the discrete_space code.

Repro:

```python
from mesa.discrete_space import HexGrid
import random

grid = HexGrid((10, 10), torus=False, random=random.Random(42))
cell = grid._cells[(4, 4)]
print(sorted(c.coordinate for c in cell.connections.values()))
# currently: [(3, 4), (4, 3), (4, 5), (5, 3), (5, 4), (5, 5)]
# but cell.position (set in _init_hex_geometry, same file) puts the true
# nearest neighbors at [(3, 3), (3, 4), (3, 5), (4, 3), (4, 5), (5, 4)]
```

I checked this by computing the true nearest neighbors directly from the grid's own `x = sqrt(3)*(col + 0.5*(row%2))`, `y = 1.5*row` position formula, independent of `_connect_cells_2d`. Every cell in a 10x10 grid, torus and non-torus, disagrees with its geometrically-true neighbors under the current code.

### Implementation
One-line fix in `_connect_cells_2d`: the ternary had `odd_offsets` and `even_offsets` backwards relative to row parity.

`test_hexgrid` and the HexGrid block in `test_cell_neighborhood` asserted the buggy neighbor coordinates and counts as correct, so I fixed those expected values against the same independent position-based geometry rather than against the fixed code's own output. I also added `test_hexgrid_connectivity_matches_geometry`, which checks every cell's connections against its nearest neighbors by physical position, for both torus and non-torus grids, so this exact bug can't come back unnoticed.

### Testing
- `pytest --cov=mesa tests/`: 682 passed (681 baseline + 1 new test), 86% coverage, no regression from main
- `ruff format --diff` / `ruff check`: clean
- Confirmed the new regression test actually catches the bug: reverted the one-line fix temporarily, confirmed `test_hexgrid_connectivity_matches_geometry` fails against the unfixed code, then re-applied the fix

### Additional Notes
None.