### PR TITLE
Fix FixedAgent.remove() when agent has no cell

### DIFF
--- a/mesa/discrete_space/cell_agent.py
+++ b/mesa/discrete_space/cell_agent.py
@@ -115,7 +115,9 @@ class FixedAgent(Agent, FixedCell):
         """Remove the agent from the model."""
         super().remove()
 
-        self.cell.remove_agent(self)
+        # bypasses the FixedCell setter, which rejects reassignment
+        if self.cell is not None:
+            self.cell.remove_agent(self)
         self._mesa_cell = None
 
 

--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -1218,6 +1218,43 @@ def test_fixed_agent_removal_state():
     assert agent.cell is None
 
 
+def test_fixed_agent_removal_without_cell():
+    """Test that a FixedAgent that was never placed on a cell can be removed.
+
+    This is a regression test for issue #3748:
+    FixedAgent.remove() raises AttributeError when the agent has no cell.
+    """
+    model = Model()
+    agent = FixedAgent(model)
+
+    assert agent.cell is None
+
+    agent.remove()
+
+    assert agent.cell is None
+    assert agent not in model._all_agents
+
+
+def test_remove_all_agents_with_unplaced_fixed_agent():
+    """Test that a model with an unplaced FixedAgent can still be torn down.
+
+    This is a regression test for issue #3748: remove_all_agents() crashed on
+    any FixedAgent that was never assigned a cell.
+    """
+    model = Model()
+    cell = Cell((1,), capacity=None, random=random.Random())
+    placed_agent = FixedAgent(model)
+    placed_agent.cell = cell
+    unplaced_agent = FixedAgent(model)
+
+    model.remove_all_agents()
+
+    assert placed_agent not in cell.agents
+    assert placed_agent.cell is None
+    assert unplaced_agent.cell is None
+    assert len(model._all_agents) == 0
+
+
 def test_pickling_cell():
     """Test pickling of a Cell."""
     cell = Cell((1,), capacity=1, random=random.Random(42))


### PR DESCRIPTION
### Pre-PR Checklist
- [x] This PR is a bug fix, not a new feature or enhancement.

### Summary
`FixedAgent.remove()` crashed with `AttributeError` when called on an agent that was never placed on a cell. Because `Model.remove_all_agents()` calls `remove()` on every agent, a single unplaced `FixedAgent` made the whole model impossible to tear down

### Bug / Issue

Fixes #3748.

`FixedAgent.remove()` called `self.cell.remove_agent(self)` unconditionally. When the agent had never been assigned a cell, `self.cell` is `None`, so this raised `AttributeError: 'NoneType' object has no attribute 'remove_agent'`.

Expected: removing a `FixedAgent` with no cell should succeed as a no-op for the cell part, the same way `CellAgent.remove()` already behaves. This also is an internal inconsistency between the two agent types.

Reproduction:

from mesa import Model
from mesa.discrete_space import FixedAgent

model = Model(rng=1)
agent = FixedAgent(model)   # created but never placed on a cell
agent.remove()              # AttributeError before this fix

### Implementation

Guarded the cell removal in FixedAgent.remove() so it only runs when a cell is actually assigned:

```python
def remove(self):
    """Remove the agent from the model."""
    super().remove()
    # bypasses the FixedCell setter, which rejects reassignment
    if self.cell is not None:
        self.cell.remove_agent(self)
    self._mesa_cell = None
```

CellAgent.remove() solves the same problem by assigning self.cell = None, letting the HasCell setter no-op when the cell is already None. FixedAgent cannot reuse that path: the FixedCell setter raises ValueError("Cannot move agent in FixedCell") on any reassignment, which is why FixedAgent assigns _mesa_cell directly. Hence the explicit None guard rather than routing through the setter.

### Testing
Added two regression tests in tests/discrete_space/test_discrete_space.py:
- test_fixed_agent_removal_without_cell; remove() on an agent that was never placed
- test_remove_all_agents_with_unplaced_fixed_agent; the remove_all_agents() teardown path, with a mix of placed and unplaced fixed agents

Both tests fail before the change with the reported AttributeError and pass after. ruff check and ruff format --check are clean.

### Additional Notes
No API or signature changes
