### PR TITLE
Exclude unique_id from generic repr attrs to avoid duplication

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -37,7 +37,7 @@ class Agent[M: Model]:
     """
 
     _datasets: ClassVar = set()
-    _repr_excluded_fields: ClassVar[set[str]] = {"model", "current_action"}
+    _repr_excluded_fields: ClassVar[set[str]] = {"model", "current_action", "unique_id"}
 
     def __init_subclass__(cls, **kwargs):
         """Called when DatasetTrackedAgent is subclassed."""


### PR DESCRIPTION
This is a actual bug fix up committed by myself in the PR #3759 which had `repr(agent)` currently shows `unique_id` twice "<Agent id=1 unique_id=1>".

Cause
`_repr_excluded_fields` excludes `model` and `current_action` from the generic `__dict__` scan, but not `unique_id`. Since `unique_id` is also hardcoded into the format string as `id={self.unique_id}`, it ends up printed twice — once via `id=`, once via the generic attrs loop.

Fix
One-line change: add `unique_id` back to `_repr_excluded_fields`. It's still always shown via the hardcoded `id=` prefix, so nothing is lost ,it just stops leaking into the generic scan as well.