### PR TITLE
test: assert empties count after adding agents in test_empties_space

### DIFF
--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -558,8 +558,7 @@ def test_empties_space():
     for i in range(8):
         grid._cells[i].add_agent(CellAgent(model))
 
-        assert len(grid.empties) == n - 8
-
+    assert len(grid.empties) == n - 8
 
 def test_cell_missing_exception():
     """Test that CellMissingException is raised when accessing non-existent cells."""

--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -558,6 +558,8 @@ def test_empties_space():
     for i in range(8):
         grid._cells[i].add_agent(CellAgent(model))
 
+        assert len(grid.empties) == n - 8
+
 
 def test_cell_missing_exception():
     """Test that CellMissingException is raised when accessing non-existent cells."""

--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -560,6 +560,7 @@ def test_empties_space():
 
     assert len(grid.empties) == n - 8
 
+
 def test_cell_missing_exception():
     """Test that CellMissingException is raised when accessing non-existent cells."""
     grid = OrthogonalMooreGrid((10, 10), torus=False, random=random.Random(42))


### PR DESCRIPTION
The existing test_empties_space test only checked the initial empties count on a fresh grid, but never verified that empties updates correctly after agents are added to cells. This adds an explicit assertion that len(grid.empties) equals n minus 8 after adding 8 agents.

Closes #3745