### PR TITLE
DOC: warn about tuple-length ambiguity in Agent.create_agents

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -127,7 +127,7 @@ class Agent[M: Model]:
 
         Returns:
             AgentSet containing the agents created.
- 
+
         Warning:
             A list, tuple, ndarray, or pandas Series argument whose length
             equals n is always treated as one value per agent, even if you

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -127,6 +127,19 @@ class Agent[M: Model]:
 
         Returns:
             AgentSet containing the agents created.
+ 
+        Warning:
+            A list, tuple, ndarray, or pandas Series argument whose length
+            equals n is always treated as one value per agent, even if you
+            intended it as a single shared value. This is especially easy
+            to hit with coordinate tuples: create_agents(model, 2, pos=(10,
+            20)) does NOT give both agents pos=(10, 20); it gives agent 0
+            pos=10 and agent 1 pos=20, since the tuple's length (2) matches
+            n (2).
+
+            To share a value across all agents regardless of its length,
+            wrap it so its own length no longer matches n, e.g.:
+            create_agents(model, 2, pos=[(10, 20)] * 2)
 
         """
         agents = []


### PR DESCRIPTION
create_agents silently splits any list/tuple/ndarray/Series argument whose length equals n across agents one-per-agent, even when theargument was intended as a single shared value (e.g. a coordinate tuple). Confirmed directly:

```python
    >>> MyAgent.create_agents(model, 2, pos=(10, 20))
    Agent 1: pos = 10
    Agent 2: pos = 20
``` 

instead of both agents sharing pos=(10, 20). This doesn't fix the underlying ambiguity (that's a separate, larger discussion, i'm going to open an issue about it and reference it here but documents the footgun and the workaround for now. Pure docstring change, no behavior change.