### PR TITLE
Update Conway Streamlit example for current grid API

### DIFF
--- a/mesa/examples/basic/conways_game_of_life/st_app.py
+++ b/mesa/examples/basic/conways_game_of_life/st_app.py
@@ -50,12 +50,13 @@ if run:
         model.step()
         my_bar.progress((i / num_ticks), text="Simulation progress")
         placeholder.text(f"Step = {i}")
-        for contents, (x, y) in model.grid.coord_iter():
-            # print(f"x: {x}, y: {y}, state: {contents}")
+        for cell in model.grid.all_cells:
+            x, y = cell.coordinate
+            agent = next(iter(cell.agents), None)
             selected_row = df_grid[(df_grid["x"] == x) & (df_grid["y"] == y)]
             df_grid.loc[selected_row.index, "state"] = (
-                contents.state
-            )  # random.choice([1,2])
+                agent.state if agent is not None else 0
+            )
 
         heatmap = (
             alt.Chart(df_grid)


### PR DESCRIPTION
> [!NOTE]
> Use this template for bug fixes only. For enhancements/new features, use the feature template and get maintainer approval in an issue/discussion before opening a PR.

### Pre-PR Checklist
- [x] This PR is a bug fix, not a new feature or enhancement.

### Summary
The Conway Streamlit example still used the removed `grid.coord_iter()` API. When a user runs the simulation, the app raises an `AttributeError` during the first grid update, so the visualization cannot proceed.
Impact: this affects only the Streamlit Conway example, not Mesa’s core grid functionality or the underlying Conway model. Updating it to iterate over `grid.all_cells` restores the example’s compatibility with the current discrete-space API.

### Bug / Issue
Closes #3770 

### Implementation
Updated `st_app.py` to replace `model.grid.coord_iter()` with `model.grid.all_cells`.

### Testing
All tests pass

### Additional Notes
<!-- Add any additional information that may be relevant for the reviewers, such as potential side effects, dependencies, or related work.
-->
