### PR TITLE
Remove spurious 'List' entry from find_combinations docstring

### DIFF
--- a/mesa/experimental/meta_agents/meta_agent.py
+++ b/mesa/experimental/meta_agents/meta_agent.py
@@ -97,7 +97,6 @@ def find_combinations(
         evaluation_func: The function to evaluate combinations. Defaults to None.
         filter_func: Allows the user to specify how agents are filtered to form groups.
           Defaults to None.
-        List: The function to filter combinations. Defaults to None.
 
     Returns:
         List: The list of valuable combinations, in a tuple first agentset of valuable combination  and then the value of
@@ -162,19 +161,21 @@ def create_meta_agent(
 ) -> Any | None:
     """Create a new meta-agent class and instantiate agents.
 
-    Parameters:
-    model (Any): The model instance.
-    new_agent_class (str): The name of the new meta-agent class.
-    agents (Iterable[Any]): The agents to be included in the meta-agent.
-    meta_attributes (Dict[str, Any]): Attributes to be added to the meta-agent.
-    meta_methods (Dict[str, Callable]): Methods to be added to the meta-agent.
-    assume_constituting_agent_methods (bool): Whether to assume methods from
-    constituting_-agents as meta_agent methods.
-    assume_constituting_agent_attributes (bool): Whether to retain attributes
-    from constituting_-agents.
+    Args:
+        model: The model instance.
+        new_agent_class: The name of the new meta-agent class.
+        agents: The agents to be included in the meta-agent.
+        mesa_agent_type: The Mesa Agent (sub)class the new meta-agent should
+            inherit from. If falsy, defaults to Agent.
+        meta_attributes: Attributes to be added to the meta-agent.
+        meta_methods: Methods to be added to the meta-agent.
+        assume_constituting_agent_methods: Whether to assume methods from
+            constituting-agents as meta_agent methods.
+        assume_constituting_agent_attributes: Whether to retain attributes
+            from constituting-agents.
 
     Returns:
-        - MetaAgent Instance
+        MetaAgent instance
     """
     # Convert agents to dict, to ensure uniqueness,
     # we need a dict, not a set to keep stuff deterministic

--- a/mesa/experimental/meta_agents/meta_agent.py
+++ b/mesa/experimental/meta_agents/meta_agent.py
@@ -97,7 +97,6 @@ def find_combinations(
         evaluation_func: The function to evaluate combinations. Defaults to None.
         filter_func: Allows the user to specify how agents are filtered to form groups.
           Defaults to None.
-        List: The function to filter combinations. Defaults to None.
 
     Returns:
         List: The list of valuable combinations, in a tuple first agentset of valuable combination  and then the value of


### PR DESCRIPTION
`find_combinations` documents an argument `List` in its `Args:` section that isn't a parameter of the function:

    Args:
        model: ...
        group: ...
        size: ...
        evaluation_func: ...
        filter_func: ...
        List: The function to filter combinations. Defaults to None.   <- not a parameter

It looks like a leftover, and its description just duplicates `filter_func`. This removes the stray line so the documented arguments match the actual signature (`model`, `group`, `size`, `evaluation_func`, `filter_func`).

Found with a quick docstring-vs-signature check; this was the only such mismatch in the codebase. Mesa 4.0.0a0 / current `main`.
