### PR TITLE
Change matrix references to discord

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,34 @@
+# Copilot instructions for Mesa
+
+## Big picture (what to understand first)
+- Mesa’s public entrypoints are re-exported from `mesa/__init__.py`; keep namespace compatibility (`mesa.Model`, `mesa.Agent`, `mesa.batch_run`, `mesa.DataCollector`).
+- Core runtime is event-driven in `mesa/model.py` + `mesa/time/events.py`: `Model.step()` is wrapped into a default recurring event (`Schedule(interval=1.0)`), and time advances via `_advance_time`.
+- Agent lifecycle is automatic: `Agent.__init__` registers with `Model.register_agent`, `Agent.remove()` deregisters (`mesa/agent.py`). Avoid manual mutation of `model.agents` / `model.agents_by_type` internals.
+- Spatial APIs have two tracks: `mesa.space` is supported but maintenance-only; new discrete-space work belongs in `mesa/discrete_space/*`.
+- Visualization is Solara-based (`mesa/visualization/solara_viz.py`) and considered experimental in 3.x (`mesa/visualization/__init__.py`).
+
+## Key developer workflows
+- Install for development: `pip install -e ".[dev]"` (or CI-style: `uv pip install --system .[dev]`).
+- Main test command (matches CI intent): `pytest --durations=10 tests/ -Werror -Wdefault::PendingDeprecationWarning`.
+- Coverage run used in CI: `python -Im pytest -p pytest_cov --cov tests/`.
+- Lint/format uses Ruff (`pyproject.toml`): run `ruff check . --fix` (formatter/lint integrated via Ruff config).
+- Visualization tests require Playwright browser setup in CI (`playwright install chromium-headless-shell`).
+- Docs build from `docs/`: `make html`.
+
+## Project-specific coding patterns
+- Prefer `rng` over `seed`; `seed` paths are deprecated in `Model` and `batch_run`.
+- For repeated runs, prefer explicit `rng` lists in `batch_run`; `iterations` is deprecated (`mesa/batchrunner.py`, `docs/migration_guide.md`).
+- In event scheduling, do not use lambdas for callbacks: `Event` stores weakrefs and lambda callables can disappear (`mesa/time/events.py`).
+- In `DataCollector`, lambdas work but avoid them if models must be pickleable (`mesa/datacollection.py`).
+- If changing model stepping/time semantics, verify `run_for`, `run_until`, `schedule_event`, and `schedule_recurring` behavior together (same subsystem).
+- Preserve reserved model/agent fields from migration guide (`agents`, `random`, `time`, `steps`, `running`, `unique_id`, etc.).
+
+## Integration points and boundaries
+- `batch_run` expects models to expose `datacollector`; it reads internal collection history (`_collection_steps`) for time-aware sampling.
+- Optional dependency boundaries are explicit in extras: `network`, `viz`, `examples`, `docs`, `dev` (`pyproject.toml`). Keep imports lazy/guarded where extras may be absent.
+- Core examples live under `mesa/examples` and are CI-validated; use them as behavior references before introducing API changes.
+
+## When making changes
+- Keep backward compatibility where practical, and document user-facing API shifts in `docs/migration_guide.md`.
+- Add or update tests in `tests/` adjacent to the changed subsystem (core, discrete_space, visualization, experimental).
+- Avoid broad refactors across `space` and `discrete_space` in one PR unless migration rationale is explicit.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ _For candidates interested in participating in the Google Summer of Code (GSoC),
 
 As an open source project, Mesa welcomes contributions of many forms, and from beginners to experts. If you are
 curious or just want to see what is happening, we post our development session agendas
-and development session notes on [Mesa discussions]. We also have a threaded discussion forum on [Matrix]
+and development session notes on [Mesa discussions]. We also have a chat server on [Discord]
 for casual conversation.
 
 In no particular order, examples include:
@@ -16,7 +16,7 @@ In no particular order, examples include:
 - Tutorials
 
 No contribution is too small. Although, contributions can be too big, so let's
-discuss via [Matrix] OR via [an issue].
+discuss via [Discord] OR via [an issue].
 
 **To submit a contribution**
 
@@ -416,7 +416,7 @@ A special thanks to the following projects who offered inspiration for this cont
 [gh actions build]: https://github.com/mesa/mesa/actions/workflows/build_lint.yml
 [google style guide]: https://google.github.io/styleguide/pyguide.html
 [license]: https://github.com/mesa/mesa/blob/main/LICENSE
-[matrix]: https://matrix.to/#/#project-mesa:matrix.org`
+[discord]: https://discord.gg/9mhjwWCqD
 [mesa discussions]: https://github.com/mesa/mesa/discussions
 [pep8]: https://www.python.org/dev/peps/pep-0008
 [pre-commit]: https://github.com/pre-commit/pre-commit

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | CI/CD   | [![GitHub Actions build status](https://github.com/mesa/mesa/workflows/build/badge.svg)](https://github.com/mesa/mesa/actions) [![Coverage status](https://codecov.io/gh/mesa/mesa/branch/main/graph/badge.svg)](https://codecov.io/gh/mesa/mesa) |
 | Package | [![PyPI - Version](https://img.shields.io/pypi/v/mesa.svg?logo=pypi&label=PyPI&logoColor=gold)](https://pypi.org/project/Mesa/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/mesa.svg?color=blue&label=Downloads&logo=pypi&logoColor=gold)](https://pypi.org/project/Mesa/) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mesa.svg?logo=python&label=Python&logoColor=gold)](https://pypi.org/project/Mesa/) |
 | Meta    | [![linting - Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff) [![code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) [![Hatch project](https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg)](https://github.com/pypa/hatch) [![SPEC 0 — Minimum Supported Dependencies](https://img.shields.io/badge/SPEC-0-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0000/) |
-| Chat    | [![chat](https://img.shields.io/matrix/project-mesa:matrix.org?label=chat&logo=Matrix)](https://matrix.to/#/#project-mesa:matrix.org) |
+| Chat    | [![chat](https://img.shields.io/badge/chat-Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/9mhjwWCqD) |
 | Cite    | [![DOI](https://joss.theoj.org/papers/10.21105/joss.07668/status.svg)](https://doi.org/10.21105/joss.07668) |
 
 Mesa allows users to quickly create agent-based models using built-in
@@ -74,7 +74,7 @@ For resources or help on using Mesa, check out the following:
 -   [Docs](http://mesa.readthedocs.org/) (Mesa's documentation, API and useful snippets)
     -   [Development version docs](https://mesa.readthedocs.io/latest/) (the latest version docs if you're using a pre-release Mesa version)
 -   [Discussions](https://github.com/mesa/mesa/discussions) (GitHub threaded discussions about Mesa)
--   [Matrix Chat](https://matrix.to/#/#project-mesa:matrix.org) (Chat Forum via Matrix to talk about Mesa)
+-   [Discord](https://discord.gg/9mhjwWCqD) (Chat Forum via Discord to talk about Mesa)
 
 ## Running Mesa in Docker
 
@@ -119,7 +119,7 @@ accessible from `localhost:8765`.
 Want to join the Mesa team or just curious about what is happening with
 Mesa? You can\...
 
-> -   Join our [Matrix chat room](https://matrix.to/#/#project-mesa:matrix.org) in which questions, issues, and
+> -   Join our [Discord server](https://discord.gg/9mhjwWCqD) in which questions, issues, and
 >     ideas can be (informally) discussed.
 > -   Come to a monthly dev session (you can find dev session times,
 >     agendas and notes on [Mesa discussions](https://github.com/mesa/mesa/discussions)).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -47,7 +47,7 @@ To further explore Mesa and its features, we have the following resources availa
 
 ### Community and support
 - [Mesa GitHub Discussions](https://github.com/mesa/mesa/discussions): Join discussions, ask questions, and connect with other Mesa users.
-- [Matrix Chat](https://matrix.to/#/#project-mesa:matrix.org): Real-time chat for quick questions and community interaction.
+- [Discord](https://discord.gg/9mhjwWCqD): Real-time chat for quick questions and community interaction.
 
 Enjoy modelling with Mesa, and feel free to reach out!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,8 +16,8 @@
 :target: https://github.com/psf/black
 ```
 
-```{image} https://img.shields.io/matrix/project-mesa:matrix.org?label=chat&logo=Matrix
-:target: https://matrix.to/#/#project-mesa:matrix.org
+```{image} https://img.shields.io/badge/chat-Discord-5865F2?logo=discord&logoColor=white
+:target: https://discord.gg/9mhjwWCqD
 ```
 
 [Mesa] is an Apache2 licensed agent-based modeling (or ABM) framework in Python.
@@ -79,7 +79,7 @@ For help getting started with Mesa, check out these resources:
 - [Mesa releases] - Check what's new in the latest Mesa version
 - [Mesa Extensions] - Overview of mesa's Extensions
 - [GitHub Discussions] - Ask questions and discuss Mesa
-- [Matrix Chat Room] - Real-time chat with the Mesa community
+- [Discord] - Real-time chat with the Mesa community
 
 ### Development and Support
 
@@ -123,7 +123,7 @@ API Documentation <apis/api_main>
 [github discussions]: https://github.com/mesa/mesa/discussions
 [Mesa releases]: https://github.com/mesa/mesa/releases
 [issue tracker]: https://github.com/mesa/mesa/issues
-[matrix chat room]: https://matrix.to/#/#project-mesa:matrix.org
+[discord]: https://discord.gg/9mhjwWCqD
 [mesa]: https://github.com/mesa/mesa/
 [mesa overview]: overview
 [mesa examples]: https://mesa.readthedocs.io/stable/examples.html

--- a/mesa/examples/advanced/alliance_formation/run.py
+++ b/mesa/examples/advanced/alliance_formation/run.py
@@ -1,0 +1,7 @@
+from model import MultiLevelAllianceModel
+
+
+model = MultiLevelAllianceModel()
+
+for i in range(10):
+    model.step()

--- a/mesa/examples/advanced/alliance_formation/run.py
+++ b/mesa/examples/advanced/alliance_formation/run.py
@@ -1,6 +1,5 @@
 from model import MultiLevelAllianceModel
 
-
 model = MultiLevelAllianceModel()
 
 for i in range(10):


### PR DESCRIPTION
### Summary
Per the Dev Meeting on 4 August, I switch matrix references to discord server in documentation files. 

### Implementation
Updated references in documents to be discord server and not matrix.

