### PR TITLE
Fix FixedAgent.remove() when agent has no cell (#3748)

### DIFF
--- a/mesa/discrete_space/cell_agent.py
+++ b/mesa/discrete_space/cell_agent.py
@@ -115,8 +115,9 @@ class FixedAgent(Agent, FixedCell):
         """Remove the agent from the model."""
         super().remove()
 
-        self.cell.remove_agent(self)
-        self._mesa_cell = None
+        if self._mesa_cell is not None:
+            self._mesa_cell.remove_agent(self)
+            self._mesa_cell = None
 
 
 class Grid2DMovingAgent(CellAgent):

--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -1218,6 +1218,36 @@ def test_fixed_agent_removal_state():
     assert agent.cell is None
 
 
+def test_fixed_agent_removal_without_cell():
+    """Test that removing an unplaced FixedAgent succeeds without error."""
+    model = Model()
+    agent = FixedAgent(model)
+    assert agent.cell is None
+    assert agent in model.agents
+
+    agent.remove()
+    assert agent not in model.agents
+    assert agent.cell is None
+
+
+def test_remove_all_agents_unplaced_fixed_agent():
+    """Test that model.remove_all_agents() handles unplaced FixedAgents cleanly."""
+    model = Model()
+    cell1 = Cell((1,), capacity=None, random=random.Random())
+
+    agent1 = FixedAgent(model)
+    agent1.cell = cell1
+    agent2 = FixedAgent(model)  # unplaced
+
+    assert len(model.agents) == 2
+
+    model.remove_all_agents()
+
+    assert len(model.agents) == 0
+    assert agent1.cell is None
+    assert agent2.cell is None
+
+
 def test_pickling_cell():
     """Test pickling of a Cell."""
     cell = Cell((1,), capacity=1, random=random.Random(42))


### PR DESCRIPTION
### Pre-PR Checklist
- [x] This PR is a bug fix, not a new feature or enhancement.

### Summary
Fixes `FixedAgent.remove()` raising `AttributeError` when called on an unplaced `FixedAgent` (`cell is None`).

### Bug / Issue
Fixes #3748.

Instantiating an unplaced `FixedAgent` (`agent = FixedAgent(model)`) and calling `agent.remove()` or `model.remove_all_agents()` raised `AttributeError: 'NoneType' object has no attribute 'remove_agent'`.

### Implementation
Guarded cell removal in `FixedAgent.remove()` (`mesa/discrete_space/cell_agent.py`) with `if self._mesa_cell is not None:`, matching `CellAgent.remove()` behavior.

### Testing
Added two regression tests in `tests/discrete_space/test_discrete_space.py` verifying `FixedAgent.remove()` and `model.remove_all_agents()` with unplaced agents.

Passed `pytest` and `ruff check`.
