### PR TITLE
Add the tram route model to the experimental examples

### DIFF
--- a/mesa/examples/README.md
+++ b/mesa/examples/README.md
@@ -49,3 +49,6 @@ The experimental examples are built on Mesa APIs that live under `mesa.experimen
 
 ### [Alliance Formation Model](examples/experimental/alliance_formation)
 Demonstrates dynamic meta-agent creation: agents form alliances through a game-theoretic process, and the resulting alliances become meta-agents that can themselves form higher-level alliances.
+
+### [Tram Route Model](examples/experimental/tram_model)
+Demonstrates continuous states and thresholds: a tram accelerates, coasts, brakes and dwells its way along a route, with every transition solved for analytically and scheduled on the event queue rather than polled for on each tick.

--- a/mesa/examples/__init__.py
+++ b/mesa/examples/__init__.py
@@ -8,6 +8,7 @@ from mesa.examples.basic.conways_game_of_life.model import ConwaysGameOfLife
 from mesa.examples.basic.schelling.model import Schelling
 from mesa.examples.basic.virus_on_network.model import VirusOnNetwork
 from mesa.examples.experimental.alliance_formation.model import MultiLevelAllianceModel
+from mesa.examples.experimental.tram_model.model import TransitSystem
 
 __all__ = [
     "BoidFlockers",
@@ -18,6 +19,7 @@ __all__ = [
     "PdGrid",
     "Schelling",
     "SugarscapeG1mt",
+    "TransitSystem",
     "VirusOnNetwork",
     "WolfSheep",
 ]

--- a/mesa/examples/experimental/tram_model/Readme.md
+++ b/mesa/examples/experimental/tram_model/Readme.md
@@ -1,0 +1,61 @@
+# Tram Route Model (Continuous State Example)
+
+## Summary
+
+This model demonstrates Mesa's continuous state capability.
+
+**Overview of continuous states:** Most agent-based models advance in discrete ticks, and anything that changes smoothly -- a position, a temperature, a stock level -- has to be re-integrated by hand on every tick, with the model polling on each tick to check whether some threshold has been crossed yet. That is both wasteful (nothing interesting happens on most ticks) and imprecise (the crossing is only ever detected at the end of the tick in which it happened).
+
+A `ContinuousState` instead stores a value as a *trajectory*: a baseline value, a timestamp, and a rate of change. Reading the attribute extrapolates from that baseline to the current model time, so the value is always exact and is never wrong between ticks. Rates can be chained -- here `position' = speed` and `speed' = acceleration` -- in which case the extrapolation picks up the second-order term and becomes piecewise-quadratic.
+
+A `Threshold` builds on this. Because the trajectory is known analytically, the exact time at which a state will reach a limit can be *solved for* rather than watched for, and a single event scheduled at that moment. When the trajectory changes -- a new acceleration, a new limit -- the threshold re-solves and re-schedules itself automatically.
+
+To provide a simple demonstration of this capability is a tram route model.
+
+A single tram runs an ordered route of stations. Departing a station it accelerates at a fixed rate; on reaching cruise speed it coasts; at a brake point computed from `v^2 / 2a` it applies the brakes; on reaching zero speed it has arrived, dwells for a fixed time, and departs for the next station. Every one of those transitions is a `Threshold` crossing:
+
+```python
+_cruise_threshold = Threshold(state=speed, limit=cruise_speed, callback="start_coasting", direction="rising")
+_braking_threshold = Threshold(state=position, limit=brake_point, callback="brake", direction="rising")
+_stop_threshold = Threshold(state=speed, limit=0.0, callback="arrive_at_station", direction="falling")
+```
+
+Note that the first two limits are not constants but the `cruise_speed` and `brake_point` Observables. `brake_point` is rewritten at the start of every segment and `cruise_speed` comes from the scenario, and in both cases the threshold observes the attribute and re-solves for the new crossing time on its own; nothing has to re-arm it.
+
+The brake point is computed from the segment's *peak* speed rather than the cruise speed. On a short segment, or with weak acceleration, the tram never reaches cruise speed, so it accelerates to `sqrt(2d / (1/a + 1/b))` and brakes straight from there. Assuming cruise speed instead puts the brake point outside the segment, and a rising threshold that starts out already past its limit never fires at all.
+
+The result is a model with an empty agent step. `TransitSystem.step` only samples the tram's states for the data collector -- if you deleted it, the tram would still run its route with identical timings, driven entirely by the event queue.
+
+## How to Run
+
+Install Mesa with recommended dependencies:
+
+```
+pip install "mesa[rec]"
+```
+
+Then run the example:
+
+```
+solara run app.py
+```
+
+Open the displayed local URL in your browser.
+
+To run the model without visualization and print the collected trace:
+
+```
+python model.py
+```
+
+## Files
+
+* ``model.py``: Contains the `TransitSystem` model class and its `TramScenario`.
+* ``agents.py``: Contains the `Tram` agent class, its continuous states and its thresholds.
+* ``app.py``: Code for the interactive visualization.
+* ``utils.py``: Palette and matplotlib drawing helpers used by ``app.py``.
+
+## Further Reading
+
+The continuous state and threshold API used here lives in `mesa.experimental.states`, and builds on the reactive observables in `mesa.experimental.mesa_signals`. Both are experimental and carry no semver guarantees.
+

--- a/mesa/examples/experimental/tram_model/agents.py
+++ b/mesa/examples/experimental/tram_model/agents.py
@@ -1,0 +1,158 @@
+"""Agents for the Tram Route Model."""
+
+import math
+
+from mesa import Agent, Model
+from mesa.experimental.mesa_signals import HasEmitters, Observable
+from mesa.experimental.states import ContinuousState, Threshold
+
+
+class Tram(Agent, HasEmitters):
+    """A tram travelling an ordered route of station positions.
+
+    Attributes:
+        acceleration (Observable): Current acceleration, m/s^2.
+        speed (ContinuousState): Current speed, m/s.
+        position (ContinuousState): Current position along the route, m.
+            Chained off speed (position' = speed).
+        brake_point (Observable): Position at which braking begins for the
+            current segment, m. Updated at the start of each departure;
+            the _brake_point threshold reacts to changes automatically.
+        cruise_speed (Observable): Speed at which the tram stops accelerating,
+            m/s. An Observable rather than a plain attribute so the _cruise
+            threshold tracks it instead of a fixed limit.
+    """
+
+    acceleration = Observable(fallback_value=0.0)
+    speed = ContinuousState(fallback_value=0.0, rate=lambda a: a.acceleration)
+    position = ContinuousState(fallback_value=0.0, rate=lambda a: a.speed)
+    brake_point = Observable(fallback_value=float("inf"))
+    cruise_speed = Observable(fallback_value=15.0)
+
+    # Threshold names must not collide with the private backing attribute of any
+    # Observable they read: a Threshold called _brake_point would be found by the
+    # lookup of brake_point's own "_brake_point" store and silently shadow it.
+    _cruise_threshold = Threshold(
+        state=speed, limit=cruise_speed, callback="start_coasting", direction="rising"
+    )
+    _braking_threshold = Threshold(
+        state=position, limit=brake_point, callback="brake", direction="rising"
+    )
+    _stop_threshold = Threshold(
+        state=speed, limit=0.0, callback="arrive_at_station", direction="falling"
+    )
+
+    def __init__(
+        self,
+        model: Model,
+        route: list[float],
+        cruise_speed: float = 15.0,
+        acceleration_rate: float = 2.0,
+        deceleration_rate: float = 3.0,
+        dwell_time: float = 5.0,
+    ) -> None:
+        """Create a new tram.
+
+        Args:
+            model (Model): The model instance that contains the tram.
+            route (list[float]): Ordered station positions, in meters, to visit.
+                Must contain at least a starting position and one destination.
+            cruise_speed (float, optional): Target speed once accelerating
+                finishes, m/s. Defaults to 15.0.
+            acceleration_rate (float, optional): Acceleration while departing
+                a station, m/s^2. Defaults to 2.0.
+            deceleration_rate (float, optional): Deceleration while braking
+                into a station, m/s^2. Defaults to 3.0.
+            dwell_time (float, optional): Time spent stopped at each station
+                before departing for the next one, seconds. Defaults to 5.0.
+
+        Raises:
+            ValueError: If route has fewer than two stops.
+        """
+        super().__init__(model)
+
+        if len(route) < 2:
+            raise ValueError("route must contain at least a start and one destination")
+
+        self.route = route
+        self.acceleration_rate = acceleration_rate
+        self.deceleration_rate = deceleration_rate
+        self.dwell_time = dwell_time
+        self._segment_index = 1
+
+        # The limits the thresholds read must exist before the first
+        # ContinuousState assignment, which is what binds the thresholds.
+        self.brake_point = float("inf")
+        self.cruise_speed = cruise_speed
+
+        self.acceleration = 0.0
+        self.speed = 0.0
+        self.position = route[0]
+
+    @property
+    def next_station(self) -> float:
+        """Position of the station this tram is currently travelling towards.
+
+        Returns:
+            float: The target station's position, in meters.
+        """
+        return self.route[self._segment_index]
+
+    @property
+    def route_complete(self) -> bool:
+        """Whether the tram has visited every station on its route.
+
+        Returns:
+            bool: True once the final station has been reached.
+        """
+        return self._segment_index >= len(self.route)
+
+    def peak_speed(self) -> float:
+        """Highest speed the tram can reach before it must brake for the next stop.
+
+        On a long segment this is the cruise speed. On a short one the tram runs
+        out of room first and the profile is triangular: it accelerates to
+        v = sqrt(2d / (1/a + 1/b)) and brakes from there, never coasting.
+
+        Returns:
+            float: The peak speed for this segment, in meters per second.
+        """
+        distance = self.next_station - self.position
+        triangular = math.sqrt(
+            2.0
+            * distance
+            / (1.0 / self.acceleration_rate + 1.0 / self.deceleration_rate)
+        )
+        return min(self.cruise_speed, triangular)
+
+    def braking_distance(self) -> float:
+        """Distance needed to decelerate to a stop from this segment's peak speed.
+
+        Returns:
+            float: The braking distance, in meters.
+        """
+        return self.peak_speed() ** 2 / (2.0 * self.deceleration_rate)
+
+    def depart(self) -> None:
+        """Accelerate towards the next station."""
+        self.brake_point = self.next_station - self.braking_distance()
+        self.acceleration = self.acceleration_rate
+
+    def start_coasting(self) -> None:
+        """Stop accelerating once cruise speed is reached."""
+        self.acceleration = 0.0
+
+    def brake(self) -> None:
+        """Decelerate once the brake point for this segment is reached."""
+        self.brake_point = float("inf")
+        self.acceleration = -self.deceleration_rate
+
+    def arrive_at_station(self) -> None:
+        """Come to a stop and schedule departure for the next station, if any."""
+        self.acceleration = 0.0
+        self._segment_index += 1
+
+        if self.route_complete:
+            return
+
+        self.model.schedule_event(self.depart, after=self.dwell_time)

--- a/mesa/examples/experimental/tram_model/app.py
+++ b/mesa/examples/experimental/tram_model/app.py
@@ -1,0 +1,65 @@
+import solara
+from matplotlib.figure import Figure
+
+from mesa.examples.experimental.tram_model.model import TramScenario, TransitSystem
+from mesa.examples.experimental.tram_model.utils import (
+    POSITION_COLOR,
+    SCALE,
+    SPEED_COLOR,
+    TITLE_SIZE,
+    draw_track_view,
+    tram_portrayal,
+)
+from mesa.visualization import Slider, SolaraViz, make_plot_component
+from mesa.visualization.utils import update_counter
+
+model_params = {
+    "rng": {
+        "type": "InputText",
+        "value": 42,
+        "label": "Random Seed",
+    },
+    "n_stations": Slider("Number of stations", 20, 2, 40, 1),
+    "station_spacing": Slider("Station spacing (m)", 200, 100, 1000, 50),
+    "cruise_speed": Slider("Cruise speed (m/s)", 15, 5, 30, 1),
+    "acceleration_rate": Slider("Acceleration (m/s^2)", 2.0, 0.5, 5.0, 0.5),
+    "deceleration_rate": Slider("Deceleration (m/s^2)", 3.0, 0.5, 5.0, 0.5),
+    "dwell_time": Slider("Dwell time (s)", 5, 0, 30, 1),
+}
+
+
+@solara.component
+def plot_track(model):
+    """Draw the route as a line of stations with the tram at its current position."""
+    update_counter.get()
+    tram = model.tram
+    style = tram_portrayal(tram)
+
+    fig = Figure(figsize=(7 * SCALE, 2.1 * SCALE))
+    ax = fig.subplots()
+
+    draw_track_view(ax, model, style)
+    ax.set_title(
+        f"t={model.time:.1f}s   |   {tram.position:.1f} m   |   "
+        f"{tram.speed:.1f} m/s   |   {style['phase']}",
+        color=style["color"],
+        fontsize=TITLE_SIZE,
+    )
+    fig.tight_layout()
+
+    solara.FigureMatplotlib(fig)
+
+
+SpeedPlot = make_plot_component({"Speed": SPEED_COLOR})
+PositionPlot = make_plot_component({"Position": POSITION_COLOR})
+
+
+model = TransitSystem(scenario=TramScenario())
+
+page = SolaraViz(
+    model,
+    components=[SpeedPlot, PositionPlot, plot_track],
+    model_params=model_params,
+    name="Tram Route Model",
+)
+page  # noqa

--- a/mesa/examples/experimental/tram_model/model.py
+++ b/mesa/examples/experimental/tram_model/model.py
@@ -1,0 +1,116 @@
+"""Tram Route Model.
+
+A model of a tram running a multi-station route using continuous-time
+kinematics. The tram accelerates to a cruise speed, coasts, brakes at an
+analytically-computed point before each station, and dwells before departing
+for the next one -- all without the model needing to step on every tick to
+check whether a threshold has been crossed.
+"""
+
+from mesa import Model
+from mesa.datacollection import DataCollector
+from mesa.examples.experimental.tram_model.agents import Tram
+from mesa.experimental.data_collection import DataRecorder
+from mesa.experimental.scenarios import Scenario
+
+
+class TramScenario(Scenario):
+    """Scenario for the Tram Route model.
+
+    Args:
+        n_stations: Number of stations on the route, including the origin.
+        station_spacing: Distance between consecutive stations, in meters.
+        cruise_speed: Target speed once accelerating finishes, m/s.
+        acceleration_rate: Acceleration while departing a station, m/s^2.
+        deceleration_rate: Deceleration while braking into a station, m/s^2.
+        dwell_time: Time spent stopped at each station, in seconds.
+        rng: Seed for reproducibility.
+    """
+
+    n_stations: int = 20
+    station_spacing: float = 200.0
+    cruise_speed: float = 15.0
+    acceleration_rate: float = 2.0
+    deceleration_rate: float = 3.0
+    dwell_time: float = 5.0
+
+
+class TransitSystem(Model):
+    """A minimal model containing a single tram running a multi-station route.
+
+    Attributes:
+        route (list[float]): Ordered station positions, in meters.
+        tram (Tram): The tram running the route.
+    """
+
+    def __init__(self, scenario: TramScenario = TramScenario):
+        """Create the model and its tram.
+
+        Args:
+            scenario: TramScenario containing model parameters.
+        """
+        super().__init__(scenario=scenario)
+
+        self.route = [
+            scenario.station_spacing * i for i in range(int(scenario.n_stations))
+        ]
+
+        self.tram = Tram(
+            self,
+            route=self.route,
+            cruise_speed=scenario.cruise_speed,
+            acceleration_rate=scenario.acceleration_rate,
+            deceleration_rate=scenario.deceleration_rate,
+            dwell_time=scenario.dwell_time,
+        )
+
+        self.recorder = DataRecorder(self)
+        self.data_registry.track_agents(
+            self.agents, "tram_data", ["position", "speed", "acceleration"]
+        ).record(self.recorder)
+
+        # The DataCollector is kept alongside only to feed the plots in
+        # app.py, since make_plot_component reads model.datacollector.
+        self.datacollector = DataCollector(
+            model_reporters={
+                "Position": lambda m: m.tram.position,
+                "Speed": lambda m: m.tram.speed,
+                "Acceleration": lambda m: m.tram.acceleration,
+            }
+        )
+        self.datacollector.collect(self)
+
+        # The tram is idle until it is told to leave the first station. Scheduling
+        # the departure rather than calling it directly keeps every state change
+        # on the event queue, so model.time is meaningful from the very first entry.
+        self.schedule_event(self.tram.depart, at=0.0)
+
+    def step(self) -> None:
+        """Sample the tram's continuous states once per time unit.
+
+        The tram itself needs no per-step logic: its speed and position are
+        extrapolated analytically and its transitions fire from the event
+        queue. This step exists purely to feed the DataCollector behind the
+        plots; the recorder collects without it.
+        """
+        self.datacollector.collect(self)
+
+
+if __name__ == "__main__":
+    model = TransitSystem(scenario=TramScenario())
+
+    print(f"Route: {model.route}")
+    print(
+        f"cruise_speed={model.tram.cruise_speed} m/s, "
+        f"acceleration={model.tram.acceleration_rate} m/s^2, "
+        f"deceleration={model.tram.deceleration_rate} m/s^2, "
+        f"braking_distance={model.tram.braking_distance():.2f}m\n"
+    )
+
+    model.run_until(2000.0)
+
+    print(model.recorder.get_table_dataframe("tram_data").to_string())
+
+    print(f"\nFinal time:     {model.time:.2f}")
+    print(f"Final position: {model.tram.position:.2f} m")
+    print(f"Final speed:    {model.tram.speed:.2f} m/s")

--- a/mesa/examples/experimental/tram_model/utils.py
+++ b/mesa/examples/experimental/tram_model/utils.py
@@ -1,0 +1,223 @@
+"""Drawing helpers for the Tram Route Model visualization.
+
+Everything here is presentation: the palette, the type scale, and the
+matplotlib code that turns a tram into a picture of a tram. app.py wires
+these into Solara components.
+"""
+
+from matplotlib.patches import FancyBboxPatch, Rectangle
+from matplotlib.transforms import blended_transform_factory
+
+RAIL_COLOR = "#5c6470"
+SLEEPER_COLOR = "#b9a58a"
+PLATFORM_COLOR = "#c8cdd4"
+WINDOW_COLOR = "#e8f1f8"
+HEADLIGHT_COLOR = "#ffd54f"
+TRIM_COLOR = "#1f2933"
+
+# The figure is drawn at double size, so type and marks are scaled to match.
+SCALE = 2
+TITLE_SIZE = 11 * SCALE
+LABEL_SIZE = 10 * SCALE
+TICK_SIZE = 9 * SCALE
+SPEED_COLOR = "#2a78d6"
+POSITION_COLOR = "#eb6834"
+
+PHASE_COLORS = {
+    "accelerating": "#008300",
+    "coasting": "#4a3aa7",
+    "braking": "#e34948",
+    "dwelling at station": "#a15c00",
+    "route complete": "#6b7280",
+}
+
+
+def phase(tram):
+    """Name what the tram is doing right now."""
+    if tram.route_complete:
+        return "route complete"
+    if tram.acceleration > 0:
+        return "accelerating"
+    if tram.acceleration < 0:
+        return "braking"
+    if tram.speed > 0:
+        return "coasting"
+    return "dwelling at station"
+
+
+def tram_portrayal(tram):
+    """Describe how to draw the tram, given what it is doing right now."""
+    # A plain dict rather than an AgentPortrayalStyle: that describes a scatter
+    # marker (x/y in a space, marker, size) for SpaceRenderer to draw, but this
+    # model has no space and the tram is a composite of patches. It also has no
+    # field for the phase name, which would have to ride in `tooltip`.
+    current = phase(tram)
+    return {
+        "phase": current,
+        "position": tram.position,
+        "color": PHASE_COLORS[current],
+        "edgecolor": TRIM_COLOR,
+        "linewidth": 1.1,
+        "zorder": 4,
+    }
+
+
+def draw_track(ax, route, span):
+    """Draw the ballast, rail and station platforms along the route."""
+    sleeper = span / 90
+    x = route[0]
+    while x <= route[-1]:
+        ax.plot([x, x], [0.19, 0.26], color=SLEEPER_COLOR, linewidth=2, zorder=1)
+        x += sleeper
+
+    ax.plot(
+        [route[0], route[-1]], [0.27, 0.27], color=RAIL_COLOR, linewidth=2.5, zorder=2
+    )
+
+    # Sized off the gap between stops so platforms never merge into one band.
+    spacing = span / max(len(route) - 1, 1)
+    platform = min(span * 0.018, spacing * 0.3)
+    for station in route:
+        ax.add_patch(
+            Rectangle(
+                (station - platform / 2, 0.28),
+                platform,
+                0.06,
+                facecolor=PLATFORM_COLOR,
+                edgecolor="#9aa3ad",
+                linewidth=0.5,
+                zorder=2,
+            )
+        )
+
+
+def draw_tram(ax, style, route, heading):
+    """Draw the tram body, windows and wheels centred on its position.
+
+    The body is drawn with x in axes fraction and y in data coordinates, so it
+    keeps the same shape however long the route is.
+
+    Args:
+        ax: Axes to draw on
+        style: Mapping from tram_portrayal with the tram's position and appearance
+        route: Ordered station positions, used to place the tram along the axis
+        heading: Signed speed, which end of the tram the headlight goes on
+    """
+    span = route[-1] - route[0]
+    margin = span * 0.04
+    low, high = route[0] - margin, route[-1] + margin
+    centre = (style["position"] - low) / (high - low)
+
+    transform = blended_transform_factory(ax.transAxes, ax.transData)
+    width, base, height = 0.07, 0.30, 0.26
+    left = centre - width / 2
+
+    ax.add_patch(
+        FancyBboxPatch(
+            (left, base),
+            width,
+            height,
+            boxstyle="round,pad=0,rounding_size=0.012",
+            facecolor=style["color"],
+            edgecolor=style["edgecolor"],
+            linewidth=style["linewidth"],
+            transform=transform,
+            zorder=style["zorder"],
+        )
+    )
+    # Darker skirt so the body reads as a vehicle rather than a bar.
+    ax.add_patch(
+        Rectangle(
+            (left, base),
+            width,
+            height * 0.22,
+            facecolor=style["edgecolor"],
+            alpha=0.25,
+            edgecolor="none",
+            transform=transform,
+            zorder=5,
+        )
+    )
+
+    window_y, window_h = base + height * 0.45, height * 0.34
+    for i in range(4):
+        ax.add_patch(
+            Rectangle(
+                (left + width * (0.1 + 0.21 * i), window_y),
+                width * 0.13,
+                window_h,
+                facecolor=WINDOW_COLOR,
+                edgecolor="none",
+                transform=transform,
+                zorder=5,
+            )
+        )
+
+    # Headlight at the leading end.
+    nose = left + width * (0.94 if heading >= 0 else 0.06)
+    ax.plot(
+        [nose],
+        [base + height * 0.3],
+        marker="o",
+        markersize=3,
+        color=HEADLIGHT_COLOR,
+        transform=transform,
+        zorder=6,
+    )
+
+    ax.plot(
+        [left + width * 0.25, left + width * 0.75],
+        [base - 0.015, base - 0.015],
+        linestyle="none",
+        marker="o",
+        markersize=5,
+        color=style["edgecolor"],
+        transform=transform,
+        zorder=3,
+    )
+
+    # Pantograph arm and contact bar reaching up to the overhead line.
+    ax.plot(
+        [centre - width * 0.12, centre + width * 0.1],
+        [base + height, 0.74],
+        color=style["edgecolor"],
+        linewidth=style["linewidth"],
+        transform=transform,
+        zorder=4,
+    )
+    ax.plot(
+        [centre + width * 0.02, centre + width * 0.18],
+        [0.74, 0.74],
+        color=style["edgecolor"],
+        linewidth=1.6,
+        transform=transform,
+        zorder=4,
+    )
+
+
+def draw_track_view(ax, model, style):
+    """Set up the track axis and draw the route with the tram on it."""
+    route = model.route
+    span = route[-1] - route[0]
+    margin = span * 0.04
+
+    # Overhead line the pantograph runs against.
+    ax.plot(
+        [route[0] - margin, route[-1] + margin],
+        [0.75, 0.75],
+        color=RAIL_COLOR,
+        linewidth=1,
+        zorder=1,
+    )
+
+    ax.set_xlim(route[0] - margin, route[-1] + margin)
+    ax.set_ylim(0.1, 0.95)
+
+    draw_track(ax, route, span)
+    draw_tram(ax, style, route, model.tram.speed)
+
+    ax.set_yticks([])
+    ax.set_xlabel("position along route (m)", fontsize=LABEL_SIZE)
+    ax.tick_params(axis="x", labelsize=TICK_SIZE)
+    for spine in ("left", "right", "top"):
+        ax.spines[spine].set_visible(False)

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -2,6 +2,8 @@
 import gc
 import weakref
 
+import pytest
+
 from mesa.examples import (
     BoidFlockers,
     BoltzmannWealth,
@@ -11,6 +13,7 @@ from mesa.examples import (
     PdGrid,
     Schelling,
     SugarscapeG1mt,
+    TransitSystem,
     VirusOnNetwork,
     WolfSheep,
 )
@@ -20,6 +23,7 @@ from mesa.examples.basic.boid_flockers.model import BoidsScenario
 from mesa.examples.basic.boltzmann_wealth_model.model import BoltzmannScenario
 from mesa.examples.basic.schelling.model import SchellingScenario
 from mesa.examples.experimental.alliance_formation.model import AllianceScenario
+from mesa.examples.experimental.tram_model.model import TramScenario
 
 
 def test_boltzmann_model():  # noqa: D103
@@ -214,6 +218,76 @@ def test_alliance_formation_model():  # noqa: D103
 
     model.run_for(10)
     assert len(model.agents) == len(model.network.nodes)
+
+    model.remove_all_agents()
+
+    del model
+    gc.collect()
+    assert ref() is None
+
+
+def test_tram_model_reaches_every_stop_across_parameters():
+    """The tram must stop exactly on each station for any app slider setting.
+
+    Guards two failures: a cruise speed the thresholds ignored, and a brake
+    point computed from cruise speed that falls outside a short segment, so
+    the rising threshold never fires and the tram runs away.
+    """
+    for cruise_speed, acceleration, deceleration, spacing in [
+        (5.0, 2.0, 3.0, 200.0),
+        (30.0, 2.0, 3.0, 200.0),
+        (15.0, 0.5, 0.5, 100.0),
+        (15.0, 5.0, 0.5, 100.0),
+        (30.0, 0.5, 0.5, 100.0),
+    ]:
+        scenario = TramScenario(
+            n_stations=4,
+            station_spacing=spacing,
+            cruise_speed=cruise_speed,
+            acceleration_rate=acceleration,
+            deceleration_rate=deceleration,
+        )
+        model = TransitSystem(scenario=scenario)
+        model.run_until(5000.0)
+
+        assert model.tram.route_complete
+        assert model.tram.position == pytest.approx(model.route[-1])
+        assert model.tram.speed == pytest.approx(0.0)
+
+        peak = model.datacollector.get_model_vars_dataframe()["Speed"].max()
+        assert peak <= cruise_speed + 1e-9
+
+
+def test_tram_model():  # noqa: D103
+    from mesa.examples.experimental.tram_model import app  # noqa: PLC0415
+
+    app.page  # noqa: B018
+
+    scenario = TramScenario(n_stations=4, station_spacing=200.0, rng=42)
+    model = TransitSystem(scenario=scenario)
+    ref = weakref.ref(model)
+
+    model.run_until(500.0)
+
+    # Every station is reached exactly, and the tram ends the route at rest.
+    assert model.tram.route_complete
+    assert model.tram.position == pytest.approx(model.route[-1])
+    assert model.tram.speed == pytest.approx(0.0)
+
+    df = model.datacollector.get_model_vars_dataframe()
+    assert list(df.columns) == ["Position", "Speed", "Acceleration"]
+    assert df["Speed"].max() <= scenario.cruise_speed + 1e-9
+
+    recorded = model.recorder.get_table_dataframe("tram_data")
+    assert list(recorded.columns) == [
+        "unique_id",
+        "position",
+        "speed",
+        "acceleration",
+        "time",
+    ]
+    assert (recorded["unique_id"] == model.tram.unique_id).all()
+    assert recorded["position"].iloc[-1] == pytest.approx(model.route[-1])
 
     model.remove_all_agents()
 


### PR DESCRIPTION
Adds a Tram Route Model under `mesa/examples/experimental/`, as a worked demonstration of `mesa.experimental.states` — `ContinuousState` and `Threshold`( ref #3766 )

## What it models

A single tram runs an ordered route of stations. Leaving a stop it accelerates at a fixed rate, coasts once it reaches cruise speed, brakes at an analytically-computed point, arrives, dwells, and departs for the next stop.

## Why this example

Every transition is a `Threshold` crossing rather than a per-tick check:

```python
_cruise_threshold = Threshold(state=speed, limit=cruise_speed, callback="start_coasting", direction="rising")
_braking_threshold = Threshold(state=position, limit=brake_point, callback="brake", direction="rising")
_stop_threshold = Threshold(state=speed, limit=0.0, callback="arrive_at_station", direction="falling")
```

The two things it is meant to show:

- **Chained continuous state.** `speed' = acceleration` and `position' = speed`, so position extrapolates as a piecewise quadratic and is exact at any time between events — never a stale value waiting for the next tick.
- **Limits that are Observables, not constants.** `cruise_speed` and `brake_point` are `Observable`s, and `brake_point` is rewritten at the start of every segment. The thresholds observe those attributes and re-solve for the new crossing time themselves; nothing re-arms them.

The result is a model with no per-agent step logic. `TransitSystem.step` exists only to sample for the `DataCollector` behind the plots, delete it and the tram still runs the route with identical timings, driven entirely by the event queue.

The brake point is derived from the segment's *peak* speed, `min(cruise_speed, sqrt(2d / (1/a + 1/b)))`, not from cruise speed. On a short segment, or with weak acceleration, the tram never reaches cruise speed; assuming it does puts the brake point outside the segment, and a rising threshold that begins already past its limit never fires at all. This matters because the app exposes all four kinematic parameters as sliders.

## Visualization

<img width="1920" height="1080" alt="Screenshot (327)" src="https://github.com/user-attachments/assets/682980b4-72ea-401d-b109-ed247af03930" />
<img width="1920" height="1080" alt="Screenshot (328)" src="https://github.com/user-attachments/assets/e88e603d-7430-4eef-b45c-02a7f5469f3c" />
<img width="1920" height="1080" alt="Screenshot (329)" src="https://github.com/user-attachments/assets/e2397c8b-b950-43bb-9fe0-c78dc8639470" />

