### PR TITLE
Compact the event list when canceled events dominate

### DIFF
--- a/mesa/time/events.py
+++ b/mesa/time/events.py
@@ -8,6 +8,7 @@ simulation events in chronological order while respecting event priorities. Key 
 - Weak references to prevent memory leaks from canceled events
 - Efficient event insertion and removal using a heap queue
 - Support for event cancellation without breaking the heap structure
+- Adaptive compaction, so repeated cancellation does not grow the heap without bound
 
 The module contains three main components:
 - Priority: An enumeration defining event priority levels (HIGH, DEFAULT, LOW)
@@ -122,6 +123,9 @@ class Event:
         self.function_args = function_args if function_args else []
         self.function_kwargs = function_kwargs if function_kwargs else {}
 
+        # Set by EventList.add_event, so cancel() can update the list's count.
+        self._owner: ReferenceType[EventList] | None = None
+
     def execute(self) -> None:
         """Execute this event."""
         if not self._canceled:
@@ -131,10 +135,18 @@ class Event:
 
     def cancel(self) -> None:
         """Cancel this event."""
+        if self._canceled:
+            return
+
         self._canceled = True
         self.fn = None
         self.function_args = []
         self.function_kwargs = {}
+
+        if self._owner is not None:
+            owner = self._owner()
+            if owner is not None:
+                owner._note_cancellation()
 
     def __lt__(self, other: Event) -> bool:
         """Define a total ordering for events to be used by the heapq."""
@@ -151,12 +163,14 @@ class Event:
         fn = self.fn() if self.fn is not None else None
         state["_fn_strong"] = fn
         state["fn"] = None  # Don't pickle the weak reference
+        state["_owner"] = None  # Weak references cannot be pickled
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         """Restore state after unpickling."""
         fn = state.pop("_fn_strong")
         self.__dict__.update(state)
+        self._owner = None
         # Recreate callable reference strategy.
         if fn is not None:
             self.fn = _create_callable_reference(fn)
@@ -402,13 +416,48 @@ class EventList:
     appropriate data structure. Events are sorted based on their time stamp, their priority, and their unique_id
     as a tie-breaker, guaranteeing a complete ordering.
 
+    Canceling an event leaves it on the heap so the heap invariant is not broken.
+    Models that repeatedly cancel and reschedule an event would therefore grow the
+    heap without bound, so the list counts the canceled events it holds and rebuilds
+    itself once they dominate. That count also makes len() an O(1) operation.
+
+    Attributes:
+        COMPACTION_RATIO (float): Fraction of canceled events above which the heap is rebuilt
+        COMPACTION_FLOOR (int): Minimum number of canceled events before compaction is considered
+
+    Notes:
+        An event belongs to one event list at a time. Adding the same event to a
+        second list hands ownership over, and the first list's count goes stale.
 
     """
+
+    COMPACTION_RATIO: float = 0.5
+    COMPACTION_FLOOR: int = 64
 
     def __init__(self):
         """Initialize an event list."""
         self._events: list[Event] = []
+        self._n_canceled: int = 0
+        # Built once and handed to every event, since creating it per push is costly.
+        self._self_ref: ReferenceType[EventList] = ref(self)
         heapify(self._events)
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Prepare state for pickling."""
+        state = self.__dict__.copy()
+        state["_self_ref"] = None  # Weak references cannot be pickled
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore state after unpickling.
+
+        Events drop their weak reference to this list when pickled, so it has to
+        be re-established or later cancellations would go uncounted.
+        """
+        self.__dict__.update(state)
+        self._self_ref = ref(self)
+        for event in self._events:
+            event._owner = self._self_ref
 
     def add_event(self, event: Event):
         """Add the event to the event list.
@@ -417,7 +466,25 @@ class EventList:
             event (Event): The event to be added
 
         """
+        event._owner = self._self_ref
+        if event.CANCELED:
+            self._n_canceled += 1
         heappush(self._events, event)
+
+    def _note_cancellation(self) -> None:
+        """Record a canceled event, compacting the heap once they dominate it.
+
+        Only cancellation raises the share of canceled events, since adding an
+        event grows the heap and popping one discards a tombstone. So this is
+        the single place where compaction can become worthwhile.
+        """
+        self._n_canceled += 1
+
+        if (
+            self._n_canceled > self.COMPACTION_FLOOR
+            and self._n_canceled > len(self._events) * self.COMPACTION_RATIO
+        ):
+            self.compact()
 
     def peek_ahead(self, n: int = 1) -> list[Event]:
         """Look at the first n non-canceled event in the event list.
@@ -449,7 +516,11 @@ class EventList:
             event = heappop(self._events)
 
             if not event.CANCELED:
+                # No longer on the heap, so a later cancel() must not be counted here.
+                event._owner = None
                 return event
+
+            self._n_canceled -= 1
 
         raise IndexError("Event list is empty")
 
@@ -459,6 +530,7 @@ class EventList:
         If there are many canceled events, compaction can speed up performance substantially.
         """
         self._events = [e for e in self._events if not e.CANCELED]
+        self._n_canceled = 0
         heapify(self._events)
 
     def is_empty(self) -> bool:
@@ -471,7 +543,7 @@ class EventList:
         return event in self._events
 
     def __len__(self) -> int:  # noqa
-        return sum(1 for e in self._events if not e.CANCELED)
+        return len(self._events) - self._n_canceled
 
     def __repr__(self) -> str:
         """Return a string representation of the event list."""
@@ -501,3 +573,4 @@ class EventList:
     def clear(self) -> None:
         """Clear the event list."""
         self._events.clear()
+        self._n_canceled = 0

--- a/mesa/time/events.py
+++ b/mesa/time/events.py
@@ -146,7 +146,7 @@ class Event:
         if self._owner is not None:
             owner = self._owner()
             if owner is not None:
-                owner._note_cancellation()
+                owner._on_cancellation()
 
     def __lt__(self, other: Event) -> bool:
         """Define a total ordering for events to be used by the heapq."""
@@ -422,8 +422,10 @@ class EventList:
     itself once they dominate. That count also makes len() an O(1) operation.
 
     Attributes:
-        COMPACTION_RATIO (float): Fraction of canceled events above which the heap is rebuilt
-        COMPACTION_FLOOR (int): Minimum number of canceled events before compaction is considered
+        COMPACTION_RATIO (float): Fraction of canceled events above which the heap is
+            rebuilt, which also bounds the peak heap at L / (1 - COMPACTION_RATIO)
+        COMPACTION_FLOOR (int): Minimum number of canceled events before compaction is
+            considered, so that small heaps are not rebuilt constantly
 
     Notes:
         An event belongs to one event list at a time. Adding the same event to a
@@ -431,7 +433,7 @@ class EventList:
 
     """
 
-    COMPACTION_RATIO: float = 0.5
+    COMPACTION_RATIO: float = 0.25
     COMPACTION_FLOOR: int = 64
 
     def __init__(self):
@@ -465,13 +467,21 @@ class EventList:
         Args:
             event (Event): The event to be added
 
+        Raises:
+            ValueError: If the event has already been canceled. Cancellation is
+                terminal, so such an event could never execute.
+
         """
-        event._owner = self._self_ref
         if event.CANCELED:
-            self._n_canceled += 1
+            raise ValueError(
+                "Cannot add a canceled event to an event list. Cancellation is "
+                "terminal, so the event would never execute."
+            )
+
+        event._owner = self._self_ref
         heappush(self._events, event)
 
-    def _note_cancellation(self) -> None:
+    def _on_cancellation(self) -> None:
         """Record a canceled event, compacting the heap once they dominate it.
 
         Only cancellation raises the share of canceled events, since adding an

--- a/mesa/time/events.py
+++ b/mesa/time/events.py
@@ -424,8 +424,6 @@ class EventList:
     Attributes:
         COMPACTION_RATIO (float): Fraction of canceled events above which the heap is
             rebuilt, which also bounds the peak heap at L / (1 - COMPACTION_RATIO)
-        COMPACTION_FLOOR (int): Minimum number of canceled events before compaction is
-            considered, so that small heaps are not rebuilt constantly
 
     Notes:
         An event belongs to one event list at a time. Adding the same event to a
@@ -434,7 +432,6 @@ class EventList:
     """
 
     COMPACTION_RATIO: float = 0.25
-    COMPACTION_FLOOR: int = 64
 
     def __init__(self):
         """Initialize an event list."""
@@ -490,10 +487,7 @@ class EventList:
         """
         self._n_canceled += 1
 
-        if (
-            self._n_canceled > self.COMPACTION_FLOOR
-            and self._n_canceled > len(self._events) * self.COMPACTION_RATIO
-        ):
+        if self._n_canceled > len(self._events) * self.COMPACTION_RATIO:
             self.compact()
 
     def peek_ahead(self, n: int = 1) -> list[Event]:

--- a/tests/time/test_events.py
+++ b/tests/time/test_events.py
@@ -443,7 +443,10 @@ def _recount(el):
 
 
 class TestEventListCompact:
-    def test_compact_removes_canceled(self):
+    def test_compact_removes_canceled(self, monkeypatch):
+        # ratio 1.0 needs more dead events than the heap holds, so automatic
+        # compaction never fires and compact() can be exercised on its own
+        monkeypatch.setattr(EventList, "COMPACTION_RATIO", 1.0)
         el = EventList()
         fn = MagicMock()
 
@@ -466,9 +469,8 @@ class TestEventListCompact:
 
         assert remaining == [6, 7, 8, 9]
 
-    def test_compacts_when_tombstones_dominate(self, monkeypatch):
+    def test_compacts_when_tombstones_dominate(self):
         """Cancelling alone rebuilds the heap; no further push is needed."""
-        monkeypatch.setattr(EventList, "COMPACTION_FLOOR", 4)
         el = EventList()
         fn = MagicMock()
 
@@ -482,26 +484,10 @@ class TestEventListCompact:
         assert len(el) == 0
         assert el._n_canceled == _recount(el)
 
-    def test_no_compaction_below_floor(self, monkeypatch):
-        monkeypatch.setattr(EventList, "COMPACTION_FLOOR", 64)
-        el = EventList()
-        fn = MagicMock()
-
-        events = [Event(i, fn) for i in range(10)]
-        for e in events:
-            el.add_event(e)
-        for e in events:
-            e.cancel()
-        el.add_event(Event(99, fn))
-
-        assert len(el._events) == 11
-        assert el._n_canceled == 10
-
     @pytest.mark.parametrize("ratio", [0.1, 0.25, 0.5])
     def test_ratio_bounds_the_peak_heap(self, monkeypatch, ratio):
         """The ratio caps the heap at L / (1 - ratio)."""
         monkeypatch.setattr(EventList, "COMPACTION_RATIO", ratio)
-        monkeypatch.setattr(EventList, "COMPACTION_FLOOR", 0)
         el = EventList()
         fn = MagicMock()
 
@@ -519,8 +505,7 @@ class TestEventListCompact:
 
         assert peak <= 100 / (1 - ratio) + 1
 
-    def test_compaction_preserves_ordering(self, monkeypatch):
-        monkeypatch.setattr(EventList, "COMPACTION_FLOOR", 2)
+    def test_compaction_preserves_ordering(self):
         el = EventList()
         fn = MagicMock()
 
@@ -540,6 +525,15 @@ class TestEventListCompact:
 
 
 class TestEventListCancelCount:
+    @pytest.fixture(autouse=True)
+    def _no_automatic_compaction(self, monkeypatch):
+        """Observe the count itself; rebuilding is TestEventListCompact's job.
+
+        A ratio of 1.0 would need more canceled events than the heap holds, so
+        the trigger never fires and tombstones stay put to be counted.
+        """
+        monkeypatch.setattr(EventList, "COMPACTION_RATIO", 1.0)
+
     def test_len_excludes_canceled(self):
         el = EventList()
         fn = MagicMock()

--- a/tests/time/test_events.py
+++ b/tests/time/test_events.py
@@ -497,6 +497,28 @@ class TestEventListCompact:
         assert len(el._events) == 11
         assert el._n_canceled == 10
 
+    @pytest.mark.parametrize("ratio", [0.1, 0.25, 0.5])
+    def test_ratio_bounds_the_peak_heap(self, monkeypatch, ratio):
+        """The ratio caps the heap at L / (1 - ratio)."""
+        monkeypatch.setattr(EventList, "COMPACTION_RATIO", ratio)
+        monkeypatch.setattr(EventList, "COMPACTION_FLOOR", 0)
+        el = EventList()
+        fn = MagicMock()
+
+        live = [Event(float(i), fn) for i in range(100)]
+        for event in live:
+            el.add_event(event)
+
+        peak = len(el._events)
+        for i in range(600):
+            live[i % 100].cancel()
+            replacement = Event(1000.0 + i, fn)
+            el.add_event(replacement)
+            live[i % 100] = replacement
+            peak = max(peak, len(el._events))
+
+        assert peak <= 100 / (1 - ratio) + 1
+
     def test_compaction_preserves_ordering(self, monkeypatch):
         monkeypatch.setattr(EventList, "COMPACTION_FLOOR", 2)
         el = EventList()
@@ -565,15 +587,16 @@ class TestEventListCancelCount:
         assert el._n_canceled == 1
         assert len(el) == 0
 
-    def test_event_canceled_before_add_is_counted(self):
+    def test_adding_a_canceled_event_raises(self):
         el = EventList()
         event = Event(1.0, MagicMock())
         event.cancel()
 
-        el.add_event(event)
+        with pytest.raises(ValueError, match="Cannot add a canceled event"):
+            el.add_event(event)
 
-        assert el._n_canceled == 1
-        assert len(el) == 0
+        assert len(el._events) == 0
+        assert el._n_canceled == 0
 
     def test_cancel_after_pop_is_not_counted(self):
         """A popped event has left the heap, so cancelling it must not count.

--- a/tests/time/test_events.py
+++ b/tests/time/test_events.py
@@ -2,6 +2,7 @@
 # ruff: noqa: D101, D102
 
 import gc
+import pickle
 from collections.abc import Callable
 from functools import partial
 from unittest.mock import MagicMock
@@ -432,6 +433,15 @@ class TestEventListPop:
         assert execution == list(range(5, 10))
 
 
+def _picklable_handler():
+    """Module-level callback, so events holding it can be pickled."""
+
+
+def _recount(el):
+    """Count the canceled events actually on the heap."""
+    return sum(1 for e in el._events if e.CANCELED)
+
+
 class TestEventListCompact:
     def test_compact_removes_canceled(self):
         el = EventList()
@@ -455,6 +465,193 @@ class TestEventListCompact:
             remaining.append(el.pop_event().time)
 
         assert remaining == [6, 7, 8, 9]
+
+    def test_compacts_when_tombstones_dominate(self, monkeypatch):
+        """Cancelling alone rebuilds the heap; no further push is needed."""
+        monkeypatch.setattr(EventList, "COMPACTION_FLOOR", 4)
+        el = EventList()
+        fn = MagicMock()
+
+        events = [Event(i, fn) for i in range(10)]
+        for e in events:
+            el.add_event(e)
+        for e in events:
+            e.cancel()
+
+        assert len(el._events) < 10
+        assert len(el) == 0
+        assert el._n_canceled == _recount(el)
+
+    def test_no_compaction_below_floor(self, monkeypatch):
+        monkeypatch.setattr(EventList, "COMPACTION_FLOOR", 64)
+        el = EventList()
+        fn = MagicMock()
+
+        events = [Event(i, fn) for i in range(10)]
+        for e in events:
+            el.add_event(e)
+        for e in events:
+            e.cancel()
+        el.add_event(Event(99, fn))
+
+        assert len(el._events) == 11
+        assert el._n_canceled == 10
+
+    def test_compaction_preserves_ordering(self, monkeypatch):
+        monkeypatch.setattr(EventList, "COMPACTION_FLOOR", 2)
+        el = EventList()
+        fn = MagicMock()
+
+        events = [Event(float(i), fn) for i in range(12)]
+        for e in events:
+            el.add_event(e)
+        for e in events[:8]:
+            e.cancel()
+
+        el.add_event(Event(0.5, fn))
+
+        drained = []
+        while not el.is_empty():
+            drained.append(el.pop_event().time)
+
+        assert drained == [0.5, 8.0, 9.0, 10.0, 11.0]
+
+
+class TestEventListCancelCount:
+    def test_len_excludes_canceled(self):
+        el = EventList()
+        fn = MagicMock()
+        events = [Event(i, fn) for i in range(5)]
+        for e in events:
+            el.add_event(e)
+
+        events[0].cancel()
+        events[3].cancel()
+
+        assert len(el) == 3
+        assert len(el._events) == 5
+        assert el._n_canceled == _recount(el)
+
+    def test_count_tracks_mixed_operations(self):
+        el = EventList()
+        fn = MagicMock()
+        events = [Event(i, fn) for i in range(12)]
+        for e in events:
+            el.add_event(e)
+
+        events[1].cancel()
+        events[2].cancel()
+        assert el._n_canceled == _recount(el)
+
+        el.pop_event()  # event 0, discards nothing
+        assert el._n_canceled == _recount(el)
+
+        el.pop_event()  # skips tombstones 1 and 2, returns event 3
+        assert el._n_canceled == _recount(el)
+
+        events[7].cancel()
+        el.compact()
+        assert el._n_canceled == _recount(el) == 0
+        assert len(el) == len(el._events)
+
+    def test_repeated_cancel_counts_once(self):
+        el = EventList()
+        event = Event(1.0, MagicMock())
+        el.add_event(event)
+
+        event.cancel()
+        event.cancel()
+
+        assert el._n_canceled == 1
+        assert len(el) == 0
+
+    def test_event_canceled_before_add_is_counted(self):
+        el = EventList()
+        event = Event(1.0, MagicMock())
+        event.cancel()
+
+        el.add_event(event)
+
+        assert el._n_canceled == 1
+        assert len(el) == 0
+
+    def test_cancel_after_pop_is_not_counted(self):
+        """A popped event has left the heap, so cancelling it must not count.
+
+        Model.schedule_event returns the Event to the caller, so cancelling one
+        that has already fired is reachable from user code.
+        """
+        el = EventList()
+        fn = MagicMock()
+        popped = Event(1.0, fn)
+        el.add_event(popped)
+        el.add_event(Event(2.0, fn))
+
+        assert el.pop_event() is popped
+        popped.cancel()
+
+        assert el._n_canceled == 0
+        assert len(el) == 1
+
+    def test_adding_popped_event_again_restores_counting(self):
+        el = EventList()
+        event = Event(1.0, MagicMock())
+        el.add_event(event)
+
+        el.pop_event()
+        el.add_event(event)
+        event.cancel()
+
+        assert el._n_canceled == 1
+        assert len(el) == 0
+
+    def test_clear_resets_count(self):
+        el = EventList()
+        event = Event(1.0, MagicMock())
+        el.add_event(event)
+        event.cancel()
+
+        el.clear()
+
+        assert el._n_canceled == 0
+        assert len(el) == 0
+
+    def test_is_empty_when_only_tombstones_remain(self):
+        el = EventList()
+        fn = MagicMock()
+        events = [Event(i, fn) for i in range(3)]
+        for e in events:
+            el.add_event(e)
+        for e in events:
+            e.cancel()
+
+        assert el.is_empty()
+        assert len(el._events) == 3
+
+    def test_cancel_after_list_is_collected(self):
+        el = EventList()
+        event = Event(1.0, MagicMock())
+        el.add_event(event)
+
+        del el
+        gc.collect()
+
+        event.cancel()  # must not raise
+        assert event.CANCELED
+
+    def test_pickle_roundtrip_keeps_counting(self):
+        el = EventList()
+        events = [Event(i, _picklable_handler) for i in range(4)]
+        for e in events:
+            el.add_event(e)
+        events[0].cancel()
+
+        restored = pickle.loads(pickle.dumps(el))  # noqa: S301
+
+        assert len(restored) == 3
+        live = next(e for e in restored._events if not e.CANCELED)
+        live.cancel()
+        assert restored._n_canceled == _recount(restored)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`EventList.compact()` was added in #3359 but nothing in the library ever called it, while a comment in `EventList.remove()` already said canceled events "may trigger adaptive compaction if they dominate the heap".

Cancellation uses the tombstone pattern to keep the heap invariant, so a model that repeatedly cancels and reschedules an event grows the heap without bound. A `Threshold` whose projected crossing time keeps moving is the clearest case: 2000 agents rescheduling over 800 steps peak at 239,731 heap entries, 99.2% of them tombstones.

Wire compaction up from `cancel()` rather than from `add_event` or `pop_event`. Cancelling is the only operation that raises the share of canceled events; pushing grows the heap and popping discards a tombstone, so both move the ratio the other way.

Tracking that share needs a back-reference, because `Event.cancel()` is called straight on the event by `Action`, `Threshold` and `EventGenerator` and never routes through the list. Events therefore hold a weak reference to their list, set in `add_event` and cleared on pop, since an event that has left the heap must not be counted against it.

The same count makes `__len__` O(1) instead of a scan of the whole heap, which took 34.7 us at 1k events and 2.6 ms at 50k. `is_empty()` and `peek_ahead()` both inherit that.

Measured on the cancel-and-reschedule workload:

```
 200 agents    0.12s -> 0.11s   peak heap  14,256 ->   399
1000 agents    1.66s -> 0.97s   peak heap  89,379 -> 2,001
2000 agents   15.37s -> 5.26s   peak heap 239,731 -> 4,000
```

Peak memory at 1000 agents drops from 29.0 MB to 1.3 MB, and `len()` from 2.6 ms to 0.12 us at 50k events.

Completes (1) from #3798 