### PR TITLE
Add requirements and a `FAILED` state to `Action`

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -263,7 +263,7 @@ class Agent[M: Model]:
         The action must be in PENDING or INTERRUPTED state and the agent
         must not be currently performing another action.
 
-        If one of the action's requirements does not hold, the action moves
+        If one of the action's start requirements does not hold, the action moves
         to FAILED instead of starting and the agent stays idle. Check
         action.has_failed rather than assuming the action is running.
 
@@ -310,7 +310,7 @@ class Agent[M: Model]:
         Returns:
             True if the new action was started. False if the current action
             refused to be interrupted, or if the new action failed its
-            requirements.
+            start requirements.
 
         Notes:
             The two False cases differ in what they leave behind. A refused

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -263,6 +263,10 @@ class Agent[M: Model]:
         The action must be in PENDING or INTERRUPTED state and the agent
         must not be currently performing another action.
 
+        If one of the action's requirements does not hold, the action moves
+        to FAILED instead of starting and the agent stays idle. Check
+        action.has_failed rather than assuming the action is running.
+
         Args:
             action: The Action to perform. Must have been created with
                 this agent as its agent.
@@ -304,16 +308,23 @@ class Agent[M: Model]:
             new_action: The Action to perform instead.
 
         Returns:
-            True if the new action was started (either no current action,
-            or the current one was successfully interrupted). False if the
-            current action is non-interruptible.
+            True if the new action was started. False if the current action
+            refused to be interrupted, or if the new action failed its
+            requirements.
+
+        Notes:
+            The two False cases differ in what they leave behind. A refused
+            interruption changes nothing. A failed requirement does not roll
+            the interruption back: the old action is already INTERRUPTED and
+            the agent is left idle, since whether to resume it is the model's
+            decision.
         """
         if self.current_action is not None and not self.current_action.interrupt():
             return False
             # interrupt() already cleared current_action
 
         self.start_action(new_action)
-        return True
+        return not new_action.has_failed
 
     def cancel_action(self) -> bool:
         """Cancel the current action, ignoring interruptible flag.

--- a/mesa/experimental/actions/actions.py
+++ b/mesa/experimental/actions/actions.py
@@ -4,8 +4,8 @@ An Action represents something an agent does over time. It integrates with
 Mesa's event scheduling system for precise timing and supports interruption
 with progress tracking and optional resumption.
 
-Actions are subclassable: override on_start(), on_complete(), and
-on_interrupt() to define behavior.
+Actions are subclassable: override on_start(), on_complete(),
+on_interrupt(), and on_fail() to define behavior.
 
 Example::
 
@@ -24,7 +24,7 @@ Example::
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from enum import IntEnum, auto
 from typing import TYPE_CHECKING
 
@@ -40,6 +40,7 @@ class ActionState(IntEnum):
     ACTIVE = auto()
     COMPLETED = auto()
     INTERRUPTED = auto()
+    FAILED = auto()
 
 
 class Action:
@@ -61,7 +62,10 @@ class Action:
         priority: Importance level. Higher = more important. May be a
             callable(agent) -> float, resolved at start time.
         interruptible: Whether higher-priority actions can preempt this.
-        state: Current lifecycle state (PENDING, ACTIVE, COMPLETED, INTERRUPTED).
+        requirements: Predicates the world must satisfy for the action to
+            run. Each is a callable(agent) -> bool.
+        state: Current lifecycle state (PENDING, ACTIVE, COMPLETED,
+            INTERRUPTED, FAILED).
         progress: Time fraction completed, 0.0 to 1.0. Computed live
             while the action is active.
 
@@ -79,6 +83,9 @@ class Action:
         name: str | None = None,
         priority: float | Callable[[Agent], float] = 0.0,
         interruptible: bool = True,
+        requirements: Callable[[Agent], bool]
+        | Iterable[Callable[[Agent], bool]]
+        | None = None,
     ) -> None:
         """Initialize an Action.
 
@@ -92,11 +99,19 @@ class Action:
                 a float or a callable that receives the agent and returns
                 a float. Resolved when start() is called.
             interruptible: If False, interrupt() will fail and return False.
+            requirements: A single callable(agent) -> bool, or an iterable
+                of them.
         """
         self.agent = agent
         self.model = agent.model
         self.interruptible = interruptible
         self._name: str | None = name
+
+        if requirements is None:
+            requirements = []
+        elif callable(requirements):
+            requirements = [requirements]
+        self.requirements: list[Callable[[Agent], bool]] = list(requirements)
 
         # Store raw values (may be callables, resolved at start)
         self._duration_spec = duration
@@ -162,6 +177,11 @@ class Action:
         """Whether this action can be resumed (interrupted, not completed)."""
         return self.state is ActionState.INTERRUPTED and self._progress < 1.0
 
+    @property
+    def has_failed(self) -> bool:
+        """Whether a requirement did not hold, at start or at completion."""
+        return self.state is ActionState.FAILED
+
     # --- Lifecycle methods (override in subclasses) ---
 
     def on_start(self) -> None:
@@ -206,6 +226,19 @@ class Action:
             necessarily cancelled, not interrupted.
         """
 
+    def on_fail(self) -> None:
+        """Called when a requirement does not hold.
+
+        Override to release anything the action
+        reserved, or to record the attempt.
+
+        Notes:
+            Check self.progress to tell the two failures apart: it is 1.0
+            when the action ran its full duration and only then found the
+            requirement broken, and below 1.0 when the action never got to
+            run this attempt.
+        """
+
     # --- Execution (called by Agent, not typically by users) ---
 
     def start(self) -> Action:
@@ -215,11 +248,16 @@ class Action:
         starts from progress=0. On resume (INTERRUPTED): continues from
         existing progress with remaining duration.
 
+        If a requirement does not hold the action moves to FAILED instead,
+        firing on_fail() rather than on_start() or on_resume(). Inspect
+        state after starting rather than assuming the action is ACTIVE.
+
         Returns:
             Self, for chaining.
 
         Raises:
             ValueError: If the action is not in PENDING or INTERRUPTED state.
+                A FAILED action cannot be restarted; create a new one.
         """
         resuming = self.state is ActionState.INTERRUPTED
 
@@ -228,6 +266,12 @@ class Action:
                 f"Cannot start action in {self.state.name} state. "
                 f"Only PENDING or INTERRUPTED actions can be started."
             )
+
+        # Gate entry before duration and priority are resolved, so a failing
+        # action never fires on_start() nor schedules a completion event.
+        if not self._requirements_met():
+            self._fail()
+            return self
 
         # Resolve callables on first start only
         if not resuming:
@@ -335,13 +379,33 @@ class Action:
             self._event.cancel()
             self._event = None
 
+    def _requirements_met(self) -> bool:
+        """Whether every requirement holds right now."""
+        return all(requirement(self.agent) for requirement in self.requirements)
+
+    def _fail(self) -> None:
+        """Move to FAILED, release the agent, and fire on_fail()."""
+        self.state = ActionState.FAILED
+
+        if self.agent.current_action is self:
+            self.agent.current_action = None
+
+        self.on_fail()
+
     def _do_complete(self) -> None:
         """Handle normal completion. Called by the scheduled event."""
         if self.state is not ActionState.ACTIVE:
             return
 
+        # Progress reaches 1.0 even if a requirement broke: the full duration
+        # elapsed, only the effect is withheld.
         self._progress = 1.0
         self._event = None
+
+        if not self._requirements_met():
+            self._fail()
+            return
+
         self.state = ActionState.COMPLETED
 
         # Clear agent's reference so it's no longer busy

--- a/mesa/experimental/actions/actions.py
+++ b/mesa/experimental/actions/actions.py
@@ -43,6 +43,17 @@ class ActionState(IntEnum):
     FAILED = auto()
 
 
+def _as_predicates(
+    spec: Callable[[Agent], bool] | Iterable[Callable[[Agent], bool]] | None,
+) -> list[Callable[[Agent], bool]]:
+    """Normalise a requirement spec into a list the action owns."""
+    if spec is None:
+        return []
+    if callable(spec):
+        return [spec]
+    return list(spec)
+
+
 class Action:
     """Something an agent does over time.
 
@@ -62,8 +73,9 @@ class Action:
         priority: Importance level. Higher = more important. May be a
             callable(agent) -> float, resolved at start time.
         interruptible: Whether higher-priority actions can preempt this.
-        requirements: Predicates the world must satisfy for the action to
-            run. Each is a callable(agent) -> bool.
+        requirements: Predicates that must hold for the action to start.
+        completion_requirements: Predicates that must hold for the effect to
+            apply. Empty by default.
         state: Current lifecycle state (PENDING, ACTIVE, COMPLETED,
             INTERRUPTED, FAILED).
         progress: Time fraction completed, 0.0 to 1.0. Computed live
@@ -86,6 +98,9 @@ class Action:
         requirements: Callable[[Agent], bool]
         | Iterable[Callable[[Agent], bool]]
         | None = None,
+        completion_requirements: Callable[[Agent], bool]
+        | Iterable[Callable[[Agent], bool]]
+        | None = None,
     ) -> None:
         """Initialize an Action.
 
@@ -100,18 +115,19 @@ class Action:
                 a float. Resolved when start() is called.
             interruptible: If False, interrupt() will fail and return False.
             requirements: A single callable(agent) -> bool, or an iterable
-                of them.
+                of them. All must hold for the action to start.
+            completion_requirements: The same, checked instead when the action
+                completes, gating the effect rather than the attempt.
         """
         self.agent = agent
         self.model = agent.model
         self.interruptible = interruptible
         self._name: str | None = name
 
-        if requirements is None:
-            requirements = []
-        elif callable(requirements):
-            requirements = [requirements]
-        self.requirements: list[Callable[[Agent], bool]] = list(requirements)
+        self.requirements: list[Callable[[Agent], bool]] = _as_predicates(requirements)
+        self.completion_requirements: list[Callable[[Agent], bool]] = _as_predicates(
+            completion_requirements
+        )
 
         # Store raw values (may be callables, resolved at start)
         self._duration_spec = duration
@@ -269,7 +285,7 @@ class Action:
 
         # Gate entry before duration and priority are resolved, so a failing
         # action neither fires on_start() nor schedules a completion event.
-        if not self._requirements_met():
+        if not self._requirements_met(self.requirements):
             self._fail()
             return self
 
@@ -379,9 +395,9 @@ class Action:
             self._event.cancel()
             self._event = None
 
-    def _requirements_met(self) -> bool:
-        """Whether every requirement holds right now."""
-        return all(requirement(self.agent) for requirement in self.requirements)
+    def _requirements_met(self, requirements: list[Callable[[Agent], bool]]) -> bool:
+        """Whether every requirement in the given list holds right now."""
+        return all(requirement(self.agent) for requirement in requirements)
 
     def _fail(self) -> None:
         """Move to FAILED, release the agent, and fire on_fail()."""
@@ -402,7 +418,7 @@ class Action:
         self._progress = 1.0
         self._event = None
 
-        if not self._requirements_met():
+        if not self._requirements_met(self.completion_requirements):
             self._fail()
             return
 

--- a/mesa/experimental/actions/actions.py
+++ b/mesa/experimental/actions/actions.py
@@ -73,7 +73,7 @@ class Action:
         priority: Importance level. Higher = more important. May be a
             callable(agent) -> float, resolved at start time.
         interruptible: Whether higher-priority actions can preempt this.
-        requirements: Predicates that must hold for the action to start.
+        start_requirements: Predicates that must hold for the action to start.
         completion_requirements: Predicates that must hold for the effect to
             apply. Empty by default.
         state: Current lifecycle state (PENDING, ACTIVE, COMPLETED,
@@ -95,7 +95,7 @@ class Action:
         name: str | None = None,
         priority: float | Callable[[Agent], float] = 0.0,
         interruptible: bool = True,
-        requirements: Callable[[Agent], bool]
+        start_requirements: Callable[[Agent], bool]
         | Iterable[Callable[[Agent], bool]]
         | None = None,
         completion_requirements: Callable[[Agent], bool]
@@ -114,8 +114,8 @@ class Action:
                 a float or a callable that receives the agent and returns
                 a float. Resolved when start() is called.
             interruptible: If False, interrupt() will fail and return False.
-            requirements: A single callable(agent) -> bool, or an iterable
-                of them. All must hold for the action to start.
+            start_requirements: A single callable(agent) -> bool, or an
+                iterable of them. All must hold for the action to start.
             completion_requirements: The same, checked instead when the action
                 completes, gating the effect rather than the attempt.
         """
@@ -124,7 +124,9 @@ class Action:
         self.interruptible = interruptible
         self._name: str | None = name
 
-        self.requirements: list[Callable[[Agent], bool]] = _as_predicates(requirements)
+        self.start_requirements: list[Callable[[Agent], bool]] = _as_predicates(
+            start_requirements
+        )
         self.completion_requirements: list[Callable[[Agent], bool]] = _as_predicates(
             completion_requirements
         )
@@ -285,7 +287,7 @@ class Action:
 
         # Gate entry before duration and priority are resolved, so a failing
         # action neither fires on_start() nor schedules a completion event.
-        if not self._requirements_met(self.requirements):
+        if not self._requirements_met(self.start_requirements):
             self._fail()
             return self
 

--- a/mesa/experimental/actions/actions.py
+++ b/mesa/experimental/actions/actions.py
@@ -268,7 +268,7 @@ class Action:
             )
 
         # Gate entry before duration and priority are resolved, so a failing
-        # action never fires on_start() nor schedules a completion event.
+        # action neither fires on_start() nor schedules a completion event.
         if not self._requirements_met():
             self._fail()
             return self

--- a/tests/experimental/test_actions.py
+++ b/tests/experimental/test_actions.py
@@ -904,7 +904,9 @@ class TestActionFailure:
     def test_requirement_broken_at_completion_fails(self):
         model, agent = make_model_and_agent()
         agent.grass = True
-        action = TrackedAction(agent, duration=3.0, requirements=lambda a: a.grass)
+        action = TrackedAction(
+            agent, duration=3.0, completion_requirements=lambda a: a.grass
+        )
         agent.start_action(action)
 
         agent.grass = False
@@ -916,20 +918,21 @@ class TestActionFailure:
         assert action.progress == 1.0  # the duration elapsed, the effect did not apply
         assert agent.current_action is None
 
-    def test_instantaneous_action_still_rechecks(self):
-        """duration=0 completes inside start(), so both checks run."""
+    def test_instantaneous_action_checks_both_lists(self):
+        """duration=0 completes inside start(), so both gates run in one call."""
         _model, agent = make_model_and_agent()
-        calls = []
+        agent.ready = True
 
-        def once(a):
-            calls.append(a)
-            return len(calls) == 1
-
-        action = TrackedAction(agent, duration=0.0, requirements=once)
+        action = TrackedAction(
+            agent,
+            duration=0.0,
+            requirements=lambda a: a.ready,
+            completion_requirements=lambda a: False,
+        )
         agent.start_action(action)
 
         assert action.state is ActionState.FAILED
-        assert action.start_count == 1
+        assert action.start_count == 1  # it did start, then failed to land
 
 
 class TestInterruptForWithRequirements:
@@ -1108,30 +1111,67 @@ class TestRealisticScenarios:
             "done@13.0",
         ]
 
-    def test_contested_resource_fails_the_slower_agent(self):
-        """Two sheep eat the same patch; the one that finishes second fails."""
+    def test_contested_resource_is_claimed_at_the_start(self):
+        """The right pattern for a rival resource: claim it, do not re-check it.
+
+        The patch holds one serving. The first sheep claims it in on_start and
+        grazes unimpeded; the second cannot start at all and decides what to do
+        from on_fail, which is where "go elsewhere" or "wait" would live.
+        """
         model = Model()
-        patch = {"grass": True}
-        fast = Agent(model)
-        slow = Agent(model)
-        fast.energy = slow.energy = 0.0
+        patch = {"servings": 1}
+        first, second = Agent(model), Agent(model)
+        first.energy = second.energy = 0.0
+        second.looked_elsewhere = False
 
         class Graze(Action):
-            def __init__(self, sheep, duration):
+            def __init__(self, sheep):
                 super().__init__(
-                    sheep, duration=duration, requirements=lambda a: patch["grass"]
+                    sheep, duration=3.0, requirements=lambda a: patch["servings"] > 0
+                )
+
+            def on_start(self):
+                patch["servings"] -= 1  # claimed, so nobody else can take it
+
+            def on_complete(self):
+                self.agent.energy += 30
+
+            def on_fail(self):
+                self.agent.looked_elsewhere = True
+
+        first_graze = first.start_action(Graze(first))
+        second_graze = second.start_action(Graze(second))
+
+        model.run_for(4)
+
+        assert first_graze.state is ActionState.COMPLETED
+        assert first.energy == 30
+        assert second_graze.state is ActionState.FAILED
+        assert second.looked_elsewhere
+        assert second.energy == 0.0
+
+    def test_completion_requirement_for_a_condition_nobody_can_claim(self):
+        """Market hours cannot be reserved, so the check belongs at completion."""
+        model = Model()
+        trader = Agent(model)
+        trader.filled = False
+        market = {"open": True}
+
+        class Trade(Action):
+            def __init__(self, agent):
+                super().__init__(
+                    agent,
+                    duration=5.0,
+                    completion_requirements=lambda a: market["open"],
                 )
 
             def on_complete(self):
-                patch["grass"] = False
-                self.agent.energy += 30
+                self.agent.filled = True
 
-        fast_graze = fast.start_action(Graze(fast, 2.0))
-        slow_graze = slow.start_action(Graze(slow, 4.0))
+        trade = trader.start_action(Trade(trader))
+        model.run_for(2)
+        market["open"] = False  # closes while the trade is in flight
+        model.run_for(4)
 
-        model.run_for(5)
-
-        assert fast_graze.state is ActionState.COMPLETED
-        assert fast.energy == 30
-        assert slow_graze.state is ActionState.FAILED
-        assert slow.energy == 0.0
+        assert trade.state is ActionState.FAILED
+        assert not trader.filled

--- a/tests/experimental/test_actions.py
+++ b/tests/experimental/test_actions.py
@@ -781,7 +781,7 @@ class TestEdgeCases:
 # --- Requirements and failure ---
 
 
-class TestRequirementsSetup:
+class TestRequirements:
     def test_no_requirements_by_default(self):
         _model, agent = make_model_and_agent()
         assert Action(agent).requirements == []
@@ -814,47 +814,13 @@ class TestRequirementsSetup:
     def test_requirement_receives_the_agent(self):
         _model, agent = make_model_and_agent()
         seen = []
-        agent.start_action(Action(agent, requirements=lambda a: seen.append(a) or True))
+
+        def record(a):
+            seen.append(a)
+            return True
+
+        agent.start_action(Action(agent, requirements=record))
         assert seen == [agent]
-
-
-class TestRequirementsAtStart:
-    def test_failing_requirement_blocks_start(self):
-        _model, agent = make_model_and_agent()
-        action = TrackedAction(agent, requirements=lambda a: False)
-
-        agent.start_action(action)
-
-        assert action.state is ActionState.FAILED
-        assert action.has_failed
-        assert action.start_count == 0
-        assert not agent.is_busy
-
-    def test_start_failure_fires_on_fail(self):
-        _model, agent = make_model_and_agent()
-        action = TrackedAction(agent, requirements=lambda a: False)
-
-        agent.start_action(action)
-
-        assert action.failed
-        assert not action.completed
-        assert not action.interrupted
-
-    def test_start_failure_leaves_progress_at_zero(self):
-        _model, agent = make_model_and_agent()
-        action = TrackedAction(agent, requirements=lambda a: False)
-
-        agent.start_action(action)
-
-        assert action.progress == 0.0
-
-    def test_start_failure_schedules_nothing(self):
-        model, agent = make_model_and_agent()
-        before = len(model._event_list)
-
-        agent.start_action(TrackedAction(agent, requirements=lambda a: False))
-
-        assert len(model._event_list) == before
 
     def test_all_requirements_must_hold(self):
         _model, agent = make_model_and_agent()
@@ -872,6 +838,44 @@ class TestRequirementsAtStart:
 
         assert action.state is ActionState.ACTIVE
         assert action.start_count == 1
+
+    def test_requirement_is_not_checked_mid_flight(self):
+        """Broken and repaired between start and completion is not a failure."""
+        model, agent = make_model_and_agent()
+        agent.grass = True
+        action = TrackedAction(agent, duration=5.0, requirements=lambda a: a.grass)
+        agent.start_action(action)
+
+        model.run_for(2)
+        agent.grass = False
+        model.run_for(1)
+        agent.grass = True
+        model.run_for(3)
+
+        assert action.state is ActionState.COMPLETED
+        assert action.completed
+
+
+class TestActionFailure:
+    def test_failing_requirement_blocks_start(self):
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, requirements=lambda a: False)
+
+        agent.start_action(action)
+
+        assert action.state is ActionState.FAILED
+        assert action.failed
+        assert action.start_count == 0
+        assert action.progress == 0.0
+        assert not agent.is_busy
+
+    def test_start_failure_schedules_nothing(self):
+        model, agent = make_model_and_agent()
+        before = len(model._event_list)
+
+        agent.start_action(TrackedAction(agent, requirements=lambda a: False))
+
+        assert len(model._event_list) == before
 
     def test_failed_action_cannot_be_restarted(self):
         _model, agent = make_model_and_agent()
@@ -897,8 +901,6 @@ class TestRequirementsAtStart:
         assert action.resume_count == 0
         assert action.progress == pytest.approx(0.4)
 
-
-class TestRequirementsAtCompletion:
     def test_requirement_broken_at_completion_fails(self):
         model, agent = make_model_and_agent()
         agent.grass = True
@@ -911,46 +913,8 @@ class TestRequirementsAtCompletion:
         assert action.state is ActionState.FAILED
         assert action.failed
         assert not action.completed
-
-    def test_completion_failure_keeps_progress_at_one(self):
-        """The full duration elapsed; only the effect is withheld."""
-        model, agent = make_model_and_agent()
-        agent.grass = True
-        action = TrackedAction(agent, duration=3.0, requirements=lambda a: a.grass)
-        agent.start_action(action)
-
-        agent.grass = False
-        model.run_for(4)
-
-        assert action.progress == 1.0
-
-    def test_completion_failure_releases_the_agent(self):
-        model, agent = make_model_and_agent()
-        agent.grass = True
-        action = TrackedAction(agent, duration=3.0, requirements=lambda a: a.grass)
-        agent.start_action(action)
-
-        agent.grass = False
-        model.run_for(4)
-
+        assert action.progress == 1.0  # the duration elapsed, the effect did not apply
         assert agent.current_action is None
-        assert not agent.is_busy
-
-    def test_requirement_is_not_checked_mid_flight(self):
-        """Broken and repaired between start and completion is not a failure."""
-        model, agent = make_model_and_agent()
-        agent.grass = True
-        action = TrackedAction(agent, duration=5.0, requirements=lambda a: a.grass)
-        agent.start_action(action)
-
-        model.run_for(2)
-        agent.grass = False
-        model.run_for(1)
-        agent.grass = True
-        model.run_for(3)
-
-        assert action.state is ActionState.COMPLETED
-        assert action.completed
 
     def test_instantaneous_action_still_rechecks(self):
         """duration=0 completes inside start(), so both checks run."""

--- a/tests/experimental/test_actions.py
+++ b/tests/experimental/test_actions.py
@@ -18,6 +18,7 @@ class TrackedAction(Action):
         self.resume_count = 0
         self.completed = False
         self.interrupted = False
+        self.failed = False
         self.interrupt_progress = None
 
     def on_start(self):
@@ -32,6 +33,9 @@ class TrackedAction(Action):
     def on_interrupt(self, progress):
         self.interrupted = True
         self.interrupt_progress = progress
+
+    def on_fail(self):
+        self.failed = True
 
 
 def make_model_and_agent():
@@ -774,6 +778,233 @@ class TestEdgeCases:
         assert "ACTIVE" in repr(action)
 
 
+# --- Requirements and failure ---
+
+
+class TestRequirementsSetup:
+    def test_no_requirements_by_default(self):
+        _model, agent = make_model_and_agent()
+        assert Action(agent).requirements == []
+
+    def test_single_callable_is_wrapped(self):
+        _model, agent = make_model_and_agent()
+        action = Action(agent, requirements=lambda a: True)
+        assert len(action.requirements) == 1
+
+    def test_iterable_is_copied(self):
+        """The action keeps its own list, not the caller's."""
+        _model, agent = make_model_and_agent()
+        shared = [lambda a: True]
+        action = Action(agent, requirements=shared)
+        shared.append(lambda a: False)
+        assert len(action.requirements) == 1
+
+    def test_subclass_can_assign_requirements(self):
+        _model, agent = make_model_and_agent()
+
+        class Picky(Action):
+            def __init__(self, agent):
+                super().__init__(agent)
+                self.requirements = [lambda a: a.ready]
+
+        agent.ready = False
+        action = agent.start_action(Picky(agent))
+        assert action.has_failed
+
+    def test_requirement_receives_the_agent(self):
+        _model, agent = make_model_and_agent()
+        seen = []
+        agent.start_action(Action(agent, requirements=lambda a: seen.append(a) or True))
+        assert seen == [agent]
+
+
+class TestRequirementsAtStart:
+    def test_failing_requirement_blocks_start(self):
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, requirements=lambda a: False)
+
+        agent.start_action(action)
+
+        assert action.state is ActionState.FAILED
+        assert action.has_failed
+        assert action.start_count == 0
+        assert not agent.is_busy
+
+    def test_start_failure_fires_on_fail(self):
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, requirements=lambda a: False)
+
+        agent.start_action(action)
+
+        assert action.failed
+        assert not action.completed
+        assert not action.interrupted
+
+    def test_start_failure_leaves_progress_at_zero(self):
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, requirements=lambda a: False)
+
+        agent.start_action(action)
+
+        assert action.progress == 0.0
+
+    def test_start_failure_schedules_nothing(self):
+        model, agent = make_model_and_agent()
+        before = len(model._event_list)
+
+        agent.start_action(TrackedAction(agent, requirements=lambda a: False))
+
+        assert len(model._event_list) == before
+
+    def test_all_requirements_must_hold(self):
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, requirements=[lambda a: True, lambda a: False])
+
+        agent.start_action(action)
+
+        assert action.has_failed
+
+    def test_action_starts_when_every_requirement_holds(self):
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, requirements=[lambda a: True, lambda a: True])
+
+        agent.start_action(action)
+
+        assert action.state is ActionState.ACTIVE
+        assert action.start_count == 1
+
+    def test_failed_action_cannot_be_restarted(self):
+        _model, agent = make_model_and_agent()
+        action = TrackedAction(agent, requirements=lambda a: False)
+        agent.start_action(action)
+
+        with pytest.raises(ValueError, match="FAILED"):
+            agent.start_action(action)
+
+    def test_requirements_rechecked_on_resume(self):
+        model, agent = make_model_and_agent()
+        agent.safe = True
+        action = TrackedAction(agent, duration=5.0, requirements=lambda a: a.safe)
+        agent.start_action(action)
+
+        model.run_for(2)
+        agent.cancel_action()
+        agent.safe = False
+
+        agent.start_action(action)
+
+        assert action.state is ActionState.FAILED
+        assert action.resume_count == 0
+        assert action.progress == pytest.approx(0.4)
+
+
+class TestRequirementsAtCompletion:
+    def test_requirement_broken_at_completion_fails(self):
+        model, agent = make_model_and_agent()
+        agent.grass = True
+        action = TrackedAction(agent, duration=3.0, requirements=lambda a: a.grass)
+        agent.start_action(action)
+
+        agent.grass = False
+        model.run_for(4)
+
+        assert action.state is ActionState.FAILED
+        assert action.failed
+        assert not action.completed
+
+    def test_completion_failure_keeps_progress_at_one(self):
+        """The full duration elapsed; only the effect is withheld."""
+        model, agent = make_model_and_agent()
+        agent.grass = True
+        action = TrackedAction(agent, duration=3.0, requirements=lambda a: a.grass)
+        agent.start_action(action)
+
+        agent.grass = False
+        model.run_for(4)
+
+        assert action.progress == 1.0
+
+    def test_completion_failure_releases_the_agent(self):
+        model, agent = make_model_and_agent()
+        agent.grass = True
+        action = TrackedAction(agent, duration=3.0, requirements=lambda a: a.grass)
+        agent.start_action(action)
+
+        agent.grass = False
+        model.run_for(4)
+
+        assert agent.current_action is None
+        assert not agent.is_busy
+
+    def test_requirement_is_not_checked_mid_flight(self):
+        """Broken and repaired between start and completion is not a failure."""
+        model, agent = make_model_and_agent()
+        agent.grass = True
+        action = TrackedAction(agent, duration=5.0, requirements=lambda a: a.grass)
+        agent.start_action(action)
+
+        model.run_for(2)
+        agent.grass = False
+        model.run_for(1)
+        agent.grass = True
+        model.run_for(3)
+
+        assert action.state is ActionState.COMPLETED
+        assert action.completed
+
+    def test_instantaneous_action_still_rechecks(self):
+        """duration=0 completes inside start(), so both checks run."""
+        _model, agent = make_model_and_agent()
+        calls = []
+
+        def once(a):
+            calls.append(a)
+            return len(calls) == 1
+
+        action = TrackedAction(agent, duration=0.0, requirements=once)
+        agent.start_action(action)
+
+        assert action.state is ActionState.FAILED
+        assert action.start_count == 1
+
+
+class TestInterruptForWithRequirements:
+    def test_returns_false_when_the_new_action_fails(self):
+        _model, agent = make_model_and_agent()
+        agent.start_action(TrackedAction(agent, duration=5.0))
+
+        assert (
+            agent.interrupt_for(TrackedAction(agent, requirements=lambda a: False))
+            is False
+        )
+
+    def test_old_action_is_not_rolled_back(self):
+        model, agent = make_model_and_agent()
+        first = TrackedAction(agent, duration=5.0)
+        agent.start_action(first)
+
+        model.run_for(2)
+        agent.interrupt_for(TrackedAction(agent, requirements=lambda a: False))
+
+        assert first.state is ActionState.INTERRUPTED
+        assert agent.current_action is None
+
+    def test_returns_true_when_the_new_action_starts(self):
+        _model, agent = make_model_and_agent()
+        agent.start_action(TrackedAction(agent, duration=5.0))
+
+        assert agent.interrupt_for(TrackedAction(agent, requirements=lambda a: True))
+
+    def test_refused_interruption_leaves_the_new_action_untouched(self):
+        _model, agent = make_model_and_agent()
+        agent.start_action(TrackedAction(agent, duration=5.0, interruptible=False))
+        replacement = TrackedAction(agent, requirements=lambda a: False)
+
+        assert agent.interrupt_for(replacement) is False
+        assert replacement.state is ActionState.PENDING
+        assert not replacement.failed
+
+
 # --- Integration: realistic scenarios ---
 
 
@@ -912,3 +1143,31 @@ class TestRealisticScenarios:
             "resume@7.0",
             "done@13.0",
         ]
+
+    def test_contested_resource_fails_the_slower_agent(self):
+        """Two sheep eat the same patch; the one that finishes second fails."""
+        model = Model()
+        patch = {"grass": True}
+        fast = Agent(model)
+        slow = Agent(model)
+        fast.energy = slow.energy = 0.0
+
+        class Graze(Action):
+            def __init__(self, sheep, duration):
+                super().__init__(
+                    sheep, duration=duration, requirements=lambda a: patch["grass"]
+                )
+
+            def on_complete(self):
+                patch["grass"] = False
+                self.agent.energy += 30
+
+        fast_graze = fast.start_action(Graze(fast, 2.0))
+        slow_graze = slow.start_action(Graze(slow, 4.0))
+
+        model.run_for(5)
+
+        assert fast_graze.state is ActionState.COMPLETED
+        assert fast.energy == 30
+        assert slow_graze.state is ActionState.FAILED
+        assert slow.energy == 0.0

--- a/tests/experimental/test_actions.py
+++ b/tests/experimental/test_actions.py
@@ -784,20 +784,20 @@ class TestEdgeCases:
 class TestRequirements:
     def test_no_requirements_by_default(self):
         _model, agent = make_model_and_agent()
-        assert Action(agent).requirements == []
+        assert Action(agent).start_requirements == []
 
     def test_single_callable_is_wrapped(self):
         _model, agent = make_model_and_agent()
-        action = Action(agent, requirements=lambda a: True)
-        assert len(action.requirements) == 1
+        action = Action(agent, start_requirements=lambda a: True)
+        assert len(action.start_requirements) == 1
 
     def test_iterable_is_copied(self):
         """The action keeps its own list, not the caller's."""
         _model, agent = make_model_and_agent()
         shared = [lambda a: True]
-        action = Action(agent, requirements=shared)
+        action = Action(agent, start_requirements=shared)
         shared.append(lambda a: False)
-        assert len(action.requirements) == 1
+        assert len(action.start_requirements) == 1
 
     def test_subclass_can_assign_requirements(self):
         _model, agent = make_model_and_agent()
@@ -805,7 +805,7 @@ class TestRequirements:
         class Picky(Action):
             def __init__(self, agent):
                 super().__init__(agent)
-                self.requirements = [lambda a: a.ready]
+                self.start_requirements = [lambda a: a.ready]
 
         agent.ready = False
         action = agent.start_action(Picky(agent))
@@ -819,12 +819,14 @@ class TestRequirements:
             seen.append(a)
             return True
 
-        agent.start_action(Action(agent, requirements=record))
+        agent.start_action(Action(agent, start_requirements=record))
         assert seen == [agent]
 
     def test_all_requirements_must_hold(self):
         _model, agent = make_model_and_agent()
-        action = TrackedAction(agent, requirements=[lambda a: True, lambda a: False])
+        action = TrackedAction(
+            agent, start_requirements=[lambda a: True, lambda a: False]
+        )
 
         agent.start_action(action)
 
@@ -832,7 +834,9 @@ class TestRequirements:
 
     def test_action_starts_when_every_requirement_holds(self):
         _model, agent = make_model_and_agent()
-        action = TrackedAction(agent, requirements=[lambda a: True, lambda a: True])
+        action = TrackedAction(
+            agent, start_requirements=[lambda a: True, lambda a: True]
+        )
 
         agent.start_action(action)
 
@@ -843,7 +847,9 @@ class TestRequirements:
         """Broken and repaired between start and completion is not a failure."""
         model, agent = make_model_and_agent()
         agent.grass = True
-        action = TrackedAction(agent, duration=5.0, requirements=lambda a: a.grass)
+        action = TrackedAction(
+            agent, duration=5.0, start_requirements=lambda a: a.grass
+        )
         agent.start_action(action)
 
         model.run_for(2)
@@ -859,7 +865,7 @@ class TestRequirements:
 class TestActionFailure:
     def test_failing_requirement_blocks_start(self):
         _model, agent = make_model_and_agent()
-        action = TrackedAction(agent, requirements=lambda a: False)
+        action = TrackedAction(agent, start_requirements=lambda a: False)
 
         agent.start_action(action)
 
@@ -873,22 +879,22 @@ class TestActionFailure:
         model, agent = make_model_and_agent()
         before = len(model._event_list)
 
-        agent.start_action(TrackedAction(agent, requirements=lambda a: False))
+        agent.start_action(TrackedAction(agent, start_requirements=lambda a: False))
 
         assert len(model._event_list) == before
 
     def test_failed_action_cannot_be_restarted(self):
         _model, agent = make_model_and_agent()
-        action = TrackedAction(agent, requirements=lambda a: False)
+        action = TrackedAction(agent, start_requirements=lambda a: False)
         agent.start_action(action)
 
         with pytest.raises(ValueError, match="FAILED"):
             agent.start_action(action)
 
-    def test_requirements_rechecked_on_resume(self):
+    def test_start_requirements_rechecked_on_resume(self):
         model, agent = make_model_and_agent()
         agent.safe = True
-        action = TrackedAction(agent, duration=5.0, requirements=lambda a: a.safe)
+        action = TrackedAction(agent, duration=5.0, start_requirements=lambda a: a.safe)
         agent.start_action(action)
 
         model.run_for(2)
@@ -926,7 +932,7 @@ class TestActionFailure:
         action = TrackedAction(
             agent,
             duration=0.0,
-            requirements=lambda a: a.ready,
+            start_requirements=lambda a: a.ready,
             completion_requirements=lambda a: False,
         )
         agent.start_action(action)
@@ -941,7 +947,9 @@ class TestInterruptForWithRequirements:
         agent.start_action(TrackedAction(agent, duration=5.0))
 
         assert (
-            agent.interrupt_for(TrackedAction(agent, requirements=lambda a: False))
+            agent.interrupt_for(
+                TrackedAction(agent, start_requirements=lambda a: False)
+            )
             is False
         )
 
@@ -951,7 +959,7 @@ class TestInterruptForWithRequirements:
         agent.start_action(first)
 
         model.run_for(2)
-        agent.interrupt_for(TrackedAction(agent, requirements=lambda a: False))
+        agent.interrupt_for(TrackedAction(agent, start_requirements=lambda a: False))
 
         assert first.state is ActionState.INTERRUPTED
         assert agent.current_action is None
@@ -960,12 +968,14 @@ class TestInterruptForWithRequirements:
         _model, agent = make_model_and_agent()
         agent.start_action(TrackedAction(agent, duration=5.0))
 
-        assert agent.interrupt_for(TrackedAction(agent, requirements=lambda a: True))
+        assert agent.interrupt_for(
+            TrackedAction(agent, start_requirements=lambda a: True)
+        )
 
     def test_refused_interruption_leaves_the_new_action_untouched(self):
         _model, agent = make_model_and_agent()
         agent.start_action(TrackedAction(agent, duration=5.0, interruptible=False))
-        replacement = TrackedAction(agent, requirements=lambda a: False)
+        replacement = TrackedAction(agent, start_requirements=lambda a: False)
 
         assert agent.interrupt_for(replacement) is False
         assert replacement.state is ActionState.PENDING
@@ -1127,7 +1137,9 @@ class TestRealisticScenarios:
         class Graze(Action):
             def __init__(self, sheep):
                 super().__init__(
-                    sheep, duration=3.0, requirements=lambda a: patch["servings"] > 0
+                    sheep,
+                    duration=3.0,
+                    start_requirements=lambda a: patch["servings"] > 0,
                 )
 
             def on_start(self):


### PR DESCRIPTION
### Summary
`Action` gains two requirement lists and a failure path. `requirements` gates the start, `completion_requirements` gates the effect, and a predicate that does not hold moves the action to `ActionState.FAILED` and fires `on_fail()` instead of letting it complete.

### Motive
An action can only succeed today. `Forage` schedules its completion the moment it starts, and five time units later `on_complete()` fires and the sheep gains energy whether or not the conditions still hold. The workaround is to re-check inside `on_complete()` and return early, which repeats the same guard in every action and still leaves the action `COMPLETED` with nothing accomplished.

Declaring the condition moves the check into the framework and gives the failure its own state, so a model can tell "ate" from "got there and could not".

### Implementation
Both lists accept a single `callable(agent) -> bool` or an iterable of them, mirroring the way `duration` and `priority` already accept callables resolved against the agent, and each is normalised into a list the action owns. Subclasses can assign to either after `super().__init__()` instead of passing them in.

`requirements` is checked at `start()`, before duration and priority are resolved, so a failing action never fires `on_start()` or `on_resume()` and never schedules a completion event.

`completion_requirements` is checked in `_do_complete()` before the effect is applied, and is empty by default. Nothing is checked at completion unless a model asks for it, which makes claim-at-start the default path.

They are separate lists rather than one list checked twice because the two questions are different, and separating them leaves the choice to the model developer. A rival resource should be claimed at the start, and the decisions that follow, take what remains, go elsewhere, or wait, belong to the agent rather than to a boolean gate. What the completion list is for is conditions nobody can reserve: a market still open when a trade lands, a counterparty still solvent at settlement.

Neither list is re-checked in between. Continuous revalidation would mean rescanning every active action whenever the world changes, which is activity scanning by another name. An action that must abort the moment a condition breaks belongs to a `Threshold` (#3766) calling `agent.cancel_action()`.

Failure moves the action to `FAILED` and fires `on_fail()` in place of `on_start()` or `on_complete()`. `_fail()` clears `agent.current_action` before firing, so the agent is already idle when the hook runs and can start something else from inside it. On a completion failure `progress` still reads `1.0`, because the full duration did elapse and only the effect is withheld.

`interrupt_for()` changes behaviour. It returned `True` unconditionally once the interruption succeeded; it now returns `not new_action.has_failed`. It deliberately does not roll the interruption back: the old action is already `INTERRUPTED` and the agent is left idle, since whether to resume it is the model's decision. The two `False` cases therefore differ in what they leave behind, a refused interruption changes nothing and a failed requirement does not.

### Usage Examples
Claiming a rival resource at the start, which is where contention belongs:

```python
class Graze(Action):
    def __init__(self, sheep, patch):
        super().__init__(sheep, duration=3.0, requirements=lambda a: patch.servings > 0)
        self.patch = patch

    def on_start(self):
        self.patch.servings -= 1  # claimed, so nobody else can take it

    def on_complete(self):
        self.agent.energy += 30

    def on_fail(self):
        self.agent.energy -= 2  # walked there for nothing
        self.agent.look_elsewhere()
```

Two sheep starting on a patch with one serving: the first claims it and grazes unimpeded, the second never starts and decides what to do next from `on_fail()`.

Gating an effect on something nobody can reserve:

```python
Trade(trader, duration=5.0, completion_requirements=lambda a: market.open)
```

A trade that starts at 15:58 and lands at 16:03 ends `FAILED`. Checking at the start would have reported the market open, which is true and useless, and there is no claim to take at 15:58 that would keep it open.

### Additional Notes
A requirement that fails on **resume** is terminal. An action interrupted at 40% whose requirement then breaks moves to `FAILED`, keeps its 0.4 progress, and cannot be restarted even once the condition is repaired; the model has to build a fresh action and lose the partial work. The alternative, sending a failed resume back to `INTERRUPTED` so it stays resumable, was rejected because `start()` would then have to accept `FAILED`, and `resuming = self.state is ActionState.INTERRUPTED` would misclassify it, calling `on_start()` instead of `on_resume()` and re-resolving duration. If transient requirements turn out to be the common case, this is the piece to revisit.

Requirements are callables, so a lambda makes a model unpicklable. That is not new, `duration=lambda a: ...` already has the same effect; named functions and bound methods pickle fine.

The third item of section 2 in #3798, giving `priority` an effect, is not here. It is #3805, which adds `Agent.should_interrupt(current, incoming)` and rewrites the same three lines of `interrupt_for()`.
