### PR TITLE
Sync agent cell reference in Cell.add_agent and Cell.remove_agent

### DIFF
--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -143,20 +143,30 @@ class Cell:
     def add_agent(self, agent: CellAgent) -> None:
         """Adds an agent to the cell.
 
+        The agent is removed from the cell it currently occupies, if any, and
+        its `cell` reference is updated to point to this cell.
+
         Args:
             agent (CellAgent): agent to add to this Cell
 
         """
-        n = len(self._agents)
-        self.empty = False
-
-        if self.capacity is not None and n >= self.capacity:
+        # capacity is checked before anything is mutated, so a CellFullException
+        # leaves both this cell and the agent untouched
+        if self.capacity is not None and len(self._agents) >= self.capacity:
             raise CellFullException(self.coordinate)
 
+        old_cell = agent._mesa_cell
+        if old_cell is not None and old_cell is not self:
+            old_cell.remove_agent(agent)
+
         self._agents.append(agent)
+        self.empty = False
+        agent._mesa_cell = self
 
     def remove_agent(self, agent: CellAgent) -> None:
         """Removes an agent from the cell.
+
+        The agent's `cell` reference is cleared as well.
 
         Args:
             agent (CellAgent): agent to remove from this cell
@@ -168,6 +178,8 @@ class Cell:
             raise AgentMissingException(agent, self.coordinate) from e
 
         self.empty = self.is_empty
+        if agent._mesa_cell is self:
+            agent._mesa_cell = None
 
     @property
     def is_empty(self) -> bool:

--- a/mesa/discrete_space/cell_agent.py
+++ b/mesa/discrete_space/cell_agent.py
@@ -44,14 +44,13 @@ class HasCell:
         if cell is old_cell:
             return
 
-        # Attempt to add first
+        # Cell.add_agent detaches from the old cell and updates _mesa_cell. It
+        # checks capacity before mutating anything, so a CellFullException
+        # leaves the agent in its original cell.
         if cell is not None:
             cell.add_agent(self)
-
-        if old_cell is not None:
+        elif old_cell is not None:
             old_cell.remove_agent(self)
-
-        self._mesa_cell = cell
 
 
 class BasicMovement:

--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -1585,3 +1585,94 @@ def test_voronoi_int_capacity_enforced_at_runtime() -> None:
     a1.move_to(cell)
     with pytest.raises(CellFullException):
         a2.move_to(cell)
+
+
+# ---------------------------------------------------------------------------
+# Section 4 — cell/agent reference sync  (regression tests for Issue #3790)
+# ---------------------------------------------------------------------------
+
+
+def test_add_agent_sets_agent_cell() -> None:
+    """Cell.add_agent must point the agent back at the cell."""
+    model = make_model()
+    cell = Cell(coordinate=(0, 0), capacity=None, random=RNG)
+
+    agent = make_agent(model)
+    cell.add_agent(agent)
+
+    assert agent in cell.agents
+    assert agent.cell is cell
+
+
+def test_remove_agent_clears_agent_cell() -> None:
+    """Cell.remove_agent must clear the agent's cell reference."""
+    model = make_model()
+    cell = Cell(coordinate=(0, 0), capacity=None, random=RNG)
+
+    agent = make_agent(model)
+    cell.add_agent(agent)
+    cell.remove_agent(agent)
+
+    assert agent not in cell.agents
+    assert agent.cell is None
+
+
+def test_add_agent_detaches_from_previous_cell() -> None:
+    """Adding an agent to a second cell must remove it from the first one."""
+    model = make_model()
+    first = Cell(coordinate=(0, 0), capacity=None, random=RNG)
+    second = Cell(coordinate=(0, 1), capacity=None, random=RNG)
+
+    agent = make_agent(model)
+    first.add_agent(agent)
+    second.add_agent(agent)
+
+    assert agent not in first.agents
+    assert first.empty
+    assert agent in second.agents
+    assert agent.cell is second
+
+
+def test_move_to_after_direct_remove_agent() -> None:
+    """move_to must work after the agent was removed through the cell itself."""
+    model = make_model()
+    first = Cell(coordinate=(0, 0), capacity=None, random=RNG)
+    second = Cell(coordinate=(0, 1), capacity=None, random=RNG)
+
+    agent = make_agent(model)
+    agent.move_to(first)
+    first.remove_agent(agent)
+
+    agent.move_to(second)  # must not raise AgentMissingException
+    assert agent.cell is second
+    assert agent in second.agents
+
+
+def test_failed_add_agent_leaves_cell_empty() -> None:
+    """A CellFullException must not mark a zero-capacity cell as occupied."""
+    model = make_model()
+    cell = Cell(coordinate=(0, 0), capacity=0, random=RNG)
+
+    with pytest.raises(CellFullException):
+        cell.add_agent(make_agent(model))
+
+    assert cell.empty
+    assert cell.is_empty
+
+
+def test_failed_move_keeps_agent_in_original_cell() -> None:
+    """A blocked move must leave both the agent and the cells unchanged."""
+    model = make_model()
+    origin = Cell(coordinate=(0, 0), capacity=None, random=RNG)
+    full = Cell(coordinate=(0, 1), capacity=1, random=RNG)
+    full.add_agent(make_agent(model))
+
+    agent = make_agent(model)
+    agent.move_to(origin)
+
+    with pytest.raises(CellFullException):
+        agent.move_to(full)
+
+    assert agent.cell is origin
+    assert agent in origin.agents
+    assert agent not in full.agents


### PR DESCRIPTION
Cell.add_agent and Cell.remove_agent only updated Cell._agents and left agent.cell alone, so the two sides could disagree. After cell.add_agent(agent) the agent still reported its cell as None, and after cell.remove_agent(agent) it still pointed at the cell it had just left. The next move_to then tried to detach the agent from a cell it was no longer in and raised AgentMissingException. Adding an agent to a second cell also left it registered in the first one.

Both methods now own the back reference. add_agent detaches the agent from its current cell and points _mesa_cell at itself, remove_agent clears it, and HasCell.cell delegates to them instead of assigning _mesa_cell on its own.

add_agent also set self.empty = False before the capacity check, so a failed add on a capacity 0 cell marked the cell as occupied. The check now runs first, so a CellFullException leaves the agent where it was.

Added regression tests for each case. Fixes #3790.