### PR TITLE
Warn once per call for dict agent_portrayal

### DIFF
--- a/mesa/visualization/backends/altair_backend.py
+++ b/mesa/visualization/backends/altair_backend.py
@@ -94,21 +94,26 @@ class AltairBackend(AbstractRenderer):
             "4": "triangle-right",
         }
 
+        # Warn only once per call instead of once per agent
+        dict_portrayal_warned = False
+
         for agent in space.agents:
             portray_input = agent_portrayal(agent)
             aps: AgentPortrayalStyle
 
             if isinstance(portray_input, dict):
-                warnings.warn(
-                    (
-                        "Returning a dict from agent_portrayal is deprecated and will be removed in Mesa 4.0. "
-                        "Please return an AgentPortrayalStyle instance instead. "
-                        "For more information, refer to the migration guide: "
-                        "https://mesa.readthedocs.io/latest/migration_guide.html#defining-portrayal-components"
-                    ),
-                    FutureWarning,
-                    stacklevel=2,
-                )
+                if not dict_portrayal_warned:
+                    warnings.warn(
+                        (
+                            "Returning a dict from agent_portrayal is deprecated and will be removed in Mesa 4.0. "
+                            "Please return an AgentPortrayalStyle instance instead. "
+                            "For more information, refer to the migration guide: "
+                            "https://mesa.readthedocs.io/latest/migration_guide.html#defining-portrayal-components"
+                        ),
+                        FutureWarning,
+                        stacklevel=2,
+                    )
+                    dict_portrayal_warned = True
                 dict_data = portray_input.copy()
                 agent_x, agent_y = self._get_agent_pos(agent, space)
 

--- a/mesa/visualization/backends/matplotlib_backend.py
+++ b/mesa/visualization/backends/matplotlib_backend.py
@@ -98,20 +98,25 @@ class MatplotlibBackend(AbstractRenderer):
         style_fields = {f.name: f.default for f in fields(AgentPortrayalStyle)}
         class_default_size = style_fields.get("size")
 
+        # Warn only once per call instead of once per agent
+        dict_portrayal_warned = False
+
         for agent in space.agents:
             portray_input = agent_portrayal(agent)
 
             if isinstance(portray_input, dict):
-                warnings.warn(
-                    (
-                        "Returning a dict from agent_portrayal is deprecated and will be removed in Mesa 4.0. "
-                        "Please return an AgentPortrayalStyle instance instead. "
-                        "For more information, refer to the migration guide: "
-                        "https://mesa.readthedocs.io/latest/migration_guide.html#defining-portrayal-components"
-                    ),
-                    FutureWarning,
-                    stacklevel=2,
-                )
+                if not dict_portrayal_warned:
+                    warnings.warn(
+                        (
+                            "Returning a dict from agent_portrayal is deprecated and will be removed in Mesa 4.0. "
+                            "Please return an AgentPortrayalStyle instance instead. "
+                            "For more information, refer to the migration guide: "
+                            "https://mesa.readthedocs.io/latest/migration_guide.html#defining-portrayal-components"
+                        ),
+                        FutureWarning,
+                        stacklevel=2,
+                    )
+                    dict_portrayal_warned = True
                 # Handle legacy dict input
                 dict_data = portray_input.copy()
                 agent_x, agent_y = self._get_agent_pos(agent, space)

--- a/mesa/visualization/mpl_space_drawing.py
+++ b/mesa/visualization/mpl_space_drawing.py
@@ -85,21 +85,26 @@ def collect_agent_data(
     style_fields = {f.name: f.default for f in fields(AgentPortrayalStyle)}
     class_default_size = style_fields.get("size")
 
+    # Warn only once per call instead of once per agent
+    dict_portrayal_warned = False
+
     for agent in space.agents:
         portray_input = agent_portrayal(agent)
         aps: AgentPortrayalStyle
 
         if isinstance(portray_input, dict):
-            warnings.warn(
-                (
-                    "Returning a dict from agent_portrayal is deprecated and will be removed in Mesa 4.0. "
-                    "Please return an AgentPortrayalStyle instance instead. "
-                    "For more information, refer to the migration guide: "
-                    "https://mesa.readthedocs.io/latest/migration_guide.html#defining-portrayal-components"
-                ),
-                FutureWarning,
-                stacklevel=2,
-            )
+            if not dict_portrayal_warned:
+                warnings.warn(
+                    (
+                        "Returning a dict from agent_portrayal is deprecated and will be removed in Mesa 4.0. "
+                        "Please return an AgentPortrayalStyle instance instead. "
+                        "For more information, refer to the migration guide: "
+                        "https://mesa.readthedocs.io/latest/migration_guide.html#defining-portrayal-components"
+                    ),
+                    FutureWarning,
+                    stacklevel=2,
+                )
+                dict_portrayal_warned = True
             dict_data = portray_input.copy()
 
             agent_x, agent_y = get_agent_pos(agent, space)

--- a/tests/visualization/test_backends.py
+++ b/tests/visualization/test_backends.py
@@ -382,6 +382,28 @@ def test_backend_collect_agent_data_projects_3d_continuous_positions(backend_cls
     np.testing.assert_allclose(data["loc"][:, 1], [0.2, 0.5])
 
 
+@pytest.mark.parametrize("backend_cls", [MatplotlibBackend, AltairBackend])
+def test_backend_collect_agent_data_warns_once_for_dict_portrayal(backend_cls):
+    """The dict portrayal FutureWarning is emitted once per call, not per agent."""
+    backend = backend_cls(space_drawer=MagicMock())
+
+    class DummyAgent:
+        position = (0, 0)
+        cell = types.SimpleNamespace(coordinate=(0, 0))
+
+    class DummySpace:
+        agents: ClassVar[list] = [DummyAgent() for _ in range(5)]
+
+    def agent_portrayal_dict(agent):
+        return {"size": 5, "color": "red", "marker": "o"}
+
+    with pytest.warns(FutureWarning) as record:
+        data = backend.collect_agent_data(DummySpace(), agent_portrayal_dict)
+
+    assert len([w for w in record if issubclass(w.category, FutureWarning)]) == 1
+    assert data["loc"].shape[0] == 5
+
+
 def test_backends_handle_errors():
     """Test error handling scenarios for invalid agent/property_layer data."""
     mb = MatplotlibBackend(space_drawer=MagicMock())

--- a/tests/visualization/test_components_matplotlib.py
+++ b/tests/visualization/test_components_matplotlib.py
@@ -1,6 +1,7 @@
 """tests for matplotlib components."""
 
 import networkx as nx
+import pytest
 from matplotlib.figure import Figure
 
 from mesa import Model
@@ -13,6 +14,7 @@ from mesa.discrete_space import (
 )
 from mesa.visualization.components import AgentPortrayalStyle, PropertyLayerStyle
 from mesa.visualization.mpl_space_drawing import (
+    collect_agent_data,
     draw_hex_grid,
     draw_network,
     draw_orthogonal_grid,
@@ -76,6 +78,23 @@ def test_draw_space():
     fig = Figure()
     ax = fig.add_subplot()
     draw_space(grid, my_portrayal, ax=ax)
+
+
+def test_collect_agent_data_warns_once_for_dict_portrayal():
+    """The dict portrayal FutureWarning is emitted once per call, not per agent."""
+    model = Model(rng=42)
+    grid = OrthogonalMooreGrid((10, 10), torus=True, random=model.random, capacity=1)
+    for _ in range(10):
+        agent = CellAgent(model)
+        agent.cell = grid.select_random_empty_cell()
+
+    def dict_portrayal(agent):
+        return {"size": 10, "color": "tab:blue", "marker": "o"}
+
+    with pytest.warns(FutureWarning) as record:
+        collect_agent_data(grid, dict_portrayal)
+
+    assert len([w for w in record if issubclass(w.category, FutureWarning)]) == 1
 
 
 def test_draw_hex_grid():


### PR DESCRIPTION
Fixes #3455.

The FutureWarning that asks you to stop returning a dict from `agent_portrayal` sits inside the per agent loop in `collect_agent_data`. With a few thousand agents you get a few thousand copies of the same message, and under Solara that repeats on every render, so the console fills up and drawing gets slower for no reason.

This adds a local flag before each of the three loops (the matplotlib backend, the altair backend, and `mpl_space_drawing.collect_agent_data`) and only warns the first time a dict portrayal turns up in that call. The dict to `AgentPortrayalStyle` conversion is unchanged, so nothing about the drawn output moves. I left the per agent `UserWarning` about ignored keys alone, since different agents can return different extra keys and folding those together would drop information.

Added tests that a multi agent dict portrayal produces exactly one FutureWarning at each of the three sites. `tests/visualization` passes with `-Werror`.