### PR TITLE
Update discord invite link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -71,8 +71,10 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at [@jackiekazil](https://matrix.to/#/@jackiekazil:matrix.org) and/or [@edgeofchaos](https://matrix.to/#/@edgeofchaos:matrix.org). Violations posted as Github comments, discussion, etc maybe also be reported via the [report functionality](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam)
-All complaints will be reviewed and investigated promptly and fairly.
+reported privately to `@jackiekazil` and/or `@edgeofchaos42` on the
+[Mesa Discord server](https://discord.gg/UUGJvdtEJu). Violations posted as
+GitHub comments or discussions may also be reported using GitHub's
+[reporting functionality](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam). All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -416,7 +416,7 @@ A special thanks to the following projects who offered inspiration for this cont
 [gh actions build]: https://github.com/mesa/mesa/actions/workflows/build_lint.yml
 [google style guide]: https://google.github.io/styleguide/pyguide.html
 [license]: https://github.com/mesa/mesa/blob/main/LICENSE
-[discord]: https://discord.gg/9mhjwWCqD
+[discord]: https://discord.gg/UUGJvdtEJu
 [mesa discussions]: https://github.com/mesa/mesa/discussions
 [pep8]: https://www.python.org/dev/peps/pep-0008
 [pre-commit]: https://github.com/pre-commit/pre-commit

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 | CI/CD   | [![GitHub Actions build status](https://github.com/mesa/mesa/workflows/build/badge.svg)](https://github.com/mesa/mesa/actions) [![Coverage status](https://codecov.io/gh/mesa/mesa/branch/main/graph/badge.svg)](https://codecov.io/gh/mesa/mesa) |
 | Package | [![PyPI - Version](https://img.shields.io/pypi/v/mesa.svg?logo=pypi&label=PyPI&logoColor=gold)](https://pypi.org/project/Mesa/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/mesa.svg?color=blue&label=Downloads&logo=pypi&logoColor=gold)](https://pypi.org/project/Mesa/) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/mesa.svg?logo=python&label=Python&logoColor=gold)](https://pypi.org/project/Mesa/) |
 | Meta    | [![linting - Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff) [![code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) [![Hatch project](https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg)](https://github.com/pypa/hatch) [![SPEC 0 — Minimum Supported Dependencies](https://img.shields.io/badge/SPEC-0-green?labelColor=%23004811&color=%235CA038)](https://scientific-python.org/specs/spec-0000/) |
-| Chat    | [![chat](https://img.shields.io/badge/chat-Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/9mhjwWCqD) |
+| Chat    | [![chat](https://img.shields.io/badge/chat-Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/UUGJvdtEJu) |
 | Cite    | [![DOI](https://joss.theoj.org/papers/10.21105/joss.07668/status.svg)](https://doi.org/10.21105/joss.07668) |
 
 Mesa allows users to quickly create agent-based models using built-in
@@ -74,7 +74,7 @@ For resources or help on using Mesa, check out the following:
 -   [Docs](http://mesa.readthedocs.org/) (Mesa's documentation, API and useful snippets)
     -   [Development version docs](https://mesa.readthedocs.io/latest/) (the latest version docs if you're using a pre-release Mesa version)
 -   [Discussions](https://github.com/mesa/mesa/discussions) (GitHub threaded discussions about Mesa)
--   [Discord](https://discord.gg/9mhjwWCqD) (Chat Forum via Discord to talk about Mesa)
+-   [Discord](https://discord.gg/UUGJvdtEJu) (Chat Forum via Discord to talk about Mesa)
 
 ## Running Mesa in Docker
 
@@ -119,7 +119,7 @@ accessible from `localhost:8765`.
 Want to join the Mesa team or just curious about what is happening with
 Mesa? You can\...
 
-> -   Join our [Discord server](https://discord.gg/9mhjwWCqD) in which questions, issues, and
+> -   Join our [Discord server](https://discord.gg/UUGJvdtEJu) in which questions, issues, and
 >     ideas can be (informally) discussed.
 > -   Come to a monthly dev session (you can find dev session times,
 >     agendas and notes on [Mesa discussions](https://github.com/mesa/mesa/discussions)).

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -47,7 +47,7 @@ To further explore Mesa and its features, we have the following resources availa
 
 ### Community and support
 - [Mesa GitHub Discussions](https://github.com/mesa/mesa/discussions): Join discussions, ask questions, and connect with other Mesa users.
-- [Discord](https://discord.gg/9mhjwWCqD): Real-time chat for quick questions and community interaction.
+- [Discord](https://discord.gg/UUGJvdtEJu): Real-time chat for quick questions and community interaction.
 
 Enjoy modelling with Mesa, and feel free to reach out!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@
 ```
 
 ```{image} https://img.shields.io/badge/chat-Discord-5865F2?logo=discord&logoColor=white
-:target: https://discord.gg/9mhjwWCqD
+:target: https://discord.gg/UUGJvdtEJu
 ```
 
 [Mesa] is an Apache2 licensed agent-based modeling (or ABM) framework in Python.
@@ -123,7 +123,7 @@ API Documentation <apis/api_main>
 [github discussions]: https://github.com/mesa/mesa/discussions
 [Mesa releases]: https://github.com/mesa/mesa/releases
 [issue tracker]: https://github.com/mesa/mesa/issues
-[discord]: https://discord.gg/9mhjwWCqD
+[discord]: https://discord.gg/UUGJvdtEJu
 [mesa]: https://github.com/mesa/mesa/
 [mesa overview]: overview
 [mesa examples]: https://mesa.readthedocs.io/stable/examples.html


### PR DESCRIPTION
The current discord invite link will expire, and this PR replaces that with a new link that doesn't. It also updates two matrix chat links in the code of conduct doc to discord chat.

<img width="576.75" height="300" alt="Screenshot 2026-08-18 at 2 17 54 PM" src="https://github.com/user-attachments/assets/0510d257-9674-4412-b869-2c212ca2072a" />
