### PR TITLE
Remove empty agent-type buckets on deregistration

### DIFF
--- a/mesa/model.py
+++ b/mesa/model.py
@@ -288,7 +288,11 @@ class Model[A: Agent, S: Scenario](HasEmitters):
             This method is called automatically by ``Agent.remove``
 
         """
-        self._agents_by_type[type(agent)].remove(agent)
+        agent_type = type(agent)
+        self._agents_by_type[agent_type].remove(agent)
+        # Drop the bucket once empty so agent_types reflects only live types.
+        if not self._agents_by_type[agent_type]:
+            del self._agents_by_type[agent_type]
         self._all_agents.remove(agent)
 
         _mesa_logger.debug(f"deregistered agent with agent_id {agent.unique_id}")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -88,6 +88,32 @@ def test_agents_by_type():
     assert len(model.agents_by_type) == 2
 
 
+def test_agent_type_bucket_removed_when_empty():
+    """Removing the last agent of a type drops it from agent_types/agents_by_type."""
+
+    class Wolf(Agent):
+        pass
+
+    class Sheep(Agent):
+        pass
+
+    model = Model()
+    wolves = [Wolf(model) for _ in range(2)]
+    Sheep(model)
+
+    assert Wolf in model.agent_types
+    assert len(model.agents_by_type) == 2
+
+    # Remove every Wolf; the type should no longer be reported.
+    for wolf in wolves:
+        wolf.remove()
+
+    assert Wolf not in model.agent_types
+    assert Wolf not in model.agents_by_type
+    assert list(model.agent_types) == [Sheep]
+    assert len(model.agents_by_type) == 1
+
+
 def test_agent_remove():
     """Test removing all agents from the model."""
 


### PR DESCRIPTION
**Describe the bug**

After the last agent of a type is removed, the type lingers in `model.agent_types` and `model.agents_by_type` as an empty bucket, so `agent_types` reports types that have no agents.

```python
from mesa import Agent, Model

class Foo(Agent): pass

m = Model(rng=1)
foos = [Foo(m) for _ in range(2)]
for f in foos:
    f.remove()

print(Foo in m.agent_types)          # True  -> no Foo agents exist
print(len(m.agents_by_type[Foo]))    # 0
```

This also makes `agents_by_type` inconsistent: `agents_by_type[T]` returns an empty set for a type that once had agents, but raises `KeyError` for a type that never had any.

**Expected behavior**

`agent_types` and `agents_by_type` should reflect only types with currently registered agents, and a type with no agents should behave the same whether it was never registered or had all its agents removed.

**Fix**

`deregister_agent` drops the per-type bucket once its last agent is removed.

**Behavior note**

After this change, `agents_by_type[T]` raises `KeyError` for a type with no current agents (previously it returned an empty set if that type had once been populated). This makes the emptied-type and never-registered-type cases consistent, but it is a behavior change, so flagging it explicitly in case exact-type-empty-set access was relied upon.

**Test**

Added `test_agent_type_bucket_removed_when_empty` (fails on the old code, passes on the fix). Full non-viz suite (584 tests) passes; ruff clean.
