### PR TITLE
Add regression test for retained empty agents_by_type bucket

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -101,3 +101,32 @@ def test_agent_remove():
 
     model.remove_all_agents()
     assert len(model.agents) == 0
+
+
+def test_agents_by_type_keeps_empty_bucket():
+    """Removing all agents of a type keeps its empty bucket in agents_by_type.
+
+    The per-type AgentSet is retained (as an empty set) after the last agent of
+    that type is removed, and the type stays listed in agent_types. Models such
+    as WolfSheep rely on this: they index agents_by_type[SomeType] every step and
+    expect an empty set rather than a KeyError once that type goes extinct.
+    """
+
+    class Predator(Agent):
+        pass
+
+    class Prey(Agent):
+        pass
+
+    model = Model()
+    for _ in range(3):
+        Predator(model)
+    for _ in range(2):
+        Prey(model)
+
+    for agent in list(model.agents_by_type[Prey]):
+        agent.remove()
+
+    assert Prey in model.agent_types
+    assert len(model.agents_by_type[Prey]) == 0
+    assert len(model.agents_by_type[Predator]) == 3


### PR DESCRIPTION
When the last agent of a given type is removed, its per-type AgentSet is kept
in agents_by_type as an empty set, and the type stays listed in agent_types.
This behavior was not covered by any test: test_agent_remove only checks that
model.agents is empty after remove_all_agents, and nothing asserted what happens
to the per-type buckets once a type goes extinct.

The behavior is relied on in practice. WolfSheep, for example, indexes
agents_by_type[Wolf] and agents_by_type[Sheep] every step and expects an empty
set rather than a KeyError once one of those populations dies out. Locking it
down with a test prevents a well-meaning change (for instance, deleting the
bucket to "clean up") from silently breaking those models.

The new test creates two agent types, removes all agents of one type, and
asserts the type is still in agent_types, that agents_by_type returns an empty
set for it, and that the other type's set is untouched. No production code is
changed.

Verified locally: full test suite passes (712 tests, examples and visualization
components included), ruff check and ruff format both clean.
