### PR TITLE
Fix inaccurate references and examples in core docstrings

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -40,7 +40,7 @@ class Agent[M: Model]:
     _repr_excluded_fields: ClassVar[set[str]] = {"model", "current_action", "unique_id"}
 
     def __init_subclass__(cls, **kwargs):
-        """Called when DatasetTrackedAgent is subclassed."""
+        """Called when Agent is subclassed, giving each subclass its own dataset set."""
         super().__init_subclass__(**kwargs)
         # Each subclass gets its own dataset set
         # we use strings on this to avoid memory leaks

--- a/mesa/discrete_space/cell.py
+++ b/mesa/discrete_space/cell.py
@@ -203,7 +203,7 @@ class Cell:
     def get_neighborhood(
         self, radius: int = 1, include_center: bool = False
     ) -> CellCollection[Cell]:
-        """Returns a list of all neighboring cells for the given radius.
+        """Returns a CellCollection of all neighboring cells for the given radius.
 
         For getting the direct neighborhood (i.e., radius=1) you can also use
         the `neighborhood` property.
@@ -213,7 +213,7 @@ class Cell:
             include_center (bool): include the center of the neighborhood
 
         Returns:
-            a list of all neighboring cells
+            a CellCollection of all neighboring cells
 
         """
         return CellCollection[Cell](

--- a/mesa/discrete_space/grid.py
+++ b/mesa/discrete_space/grid.py
@@ -324,7 +324,7 @@ class Grid(DiscreteSpace[T]):
         This is meaningfully different from :attr:`~DiscreteSpace.empties`:
         ``empties`` only includes cells with **zero** agents. If a cell has
         ``capacity=5`` and currently holds 3 agents it is **not** empty, but it
-        **is** still available. ``available_cells`` is therefore the correct
+        **is** still available. ``cells_with_capacity`` is therefore the correct
         API for models where agents share cells up to a finite limit.
 
         For cells with ``capacity=None`` (unlimited), every cell is always

--- a/mesa/experimental/mesa_signals/signal_types.py
+++ b/mesa/experimental/mesa_signals/signal_types.py
@@ -20,7 +20,7 @@ class ObservableSignals(SignalType):
         ...         super().__init__()
         ...         self._value = 0
         >>> model = MyModel()
-        >>> model.observe("value", ObservableSignals.CHANGED, lambda s: print(s.new))
+        >>> model.observe("value", ObservableSignals.CHANGED, lambda s: print(s.additional_kwargs["new"]))
         >>> model.value = 10
         10
 
@@ -59,7 +59,7 @@ class ListSignals(SignalType):
         ...         super().__init__()
         ...         self.items = []
         >>> model = MyModel()
-        >>> model.observe("items", ListSignals.INSERTED, lambda m: print(f"Inserted {m.kwargs['new']}"))
+        >>> model.observe("items", ListSignals.INSERTED, lambda m: print(f"Inserted {m.additional_kwargs['new']}"))
         >>> model.items.insert(0, "first")
         Inserted first
 


### PR DESCRIPTION
Four docstring inaccuracies in core modules, all verified against the code:

- mesa/experimental/mesa_signals/signal_types.py: the ObservableSignals.CHANGED
  and ListSignals.INSERTED examples accessed s.new and m.kwargs, which do not
  exist on the Message dataclass (its payload lives in additional_kwargs).
  Running the examples raised AttributeError. Fixed to s.additional_kwargs["new"]
  and m.additional_kwargs["new"], which run and print the documented output.

- mesa/agent.py: Agent.__init_subclass__ was documented as "Called when
  DatasetTrackedAgent is subclassed." DatasetTrackedAgent does not exist anywhere
  in the codebase. Updated to describe what the method actually does (gives each
  Agent subclass its own dataset set).

- mesa/discrete_space/grid.py: the cells_with_capacity docstring referred to the
  property as available_cells, which is not a real attribute. Corrected to
  cells_with_capacity.

- mesa/discrete_space/cell.py: Cell.get_neighborhood is annotated as and returns
  a CellCollection, but the docstring described the return as "a list". Corrected
  to CellCollection.

Docstrings only, no behavior change. Verified locally: full suite passes (739
tests), ruff check and format clean, and both corrected signal examples now run
and produce the documented output.
