### PR TITLE
Fix signal docstring examples and add doctest coverage

### DIFF
--- a/mesa/experimental/mesa_signals/signal_types.py
+++ b/mesa/experimental/mesa_signals/signal_types.py
@@ -13,14 +13,16 @@ class ObservableSignals(SignalType):
         CHANGED: Emitted when an observable's value changes.
 
     Examples:
-        >>> from mesa.experimental.mesa_signals import Observable, HasEmitters, SignalType
+        >>> from mesa.experimental.mesa_signals import Observable, HasEmitters, ObservableSignals
         >>> class MyModel(HasEmitters):
         ...     value = Observable()
         ...     def __init__(self):
         ...         super().__init__()
         ...         self._value = 0
         >>> model = MyModel()
-        >>> model.observe("value", ObservableSignals.CHANGED, lambda s: print(s.additional_kwargs["new"]))
+        >>> def handler(signal):
+        ...     print(signal.additional_kwargs["new"])
+        >>> model.observe("value", ObservableSignals.CHANGED, handler)
         >>> model.value = 10
         10
 
@@ -59,7 +61,9 @@ class ListSignals(SignalType):
         ...         super().__init__()
         ...         self.items = []
         >>> model = MyModel()
-        >>> model.observe("items", ListSignals.INSERTED, lambda m: print(f"Inserted {m.additional_kwargs['new']}"))
+        >>> def handler(message):
+        ...     print(f"Inserted {message.additional_kwargs['new']}")
+        >>> model.observe("items", ListSignals.INSERTED, handler)
         >>> model.items.insert(0, "first")
         Inserted first
 

--- a/tests/experimental/test_mesa_signals.py
+++ b/tests/experimental/test_mesa_signals.py
@@ -1,5 +1,6 @@
 """Tests for mesa_signals."""
 
+import doctest
 from unittest.mock import Mock, patch
 
 import pytest
@@ -15,8 +16,15 @@ from mesa.experimental.mesa_signals import (
     SignalType,
     computed_property,
     emit,
+    signal_types,
 )
 from mesa.experimental.mesa_signals.signals_util import Message, _AllSentinel
+
+
+def test_signal_type_docstrings():
+    """Execute signal type examples in an isolated namespace."""
+    result = doctest.testmod(signal_types, globs={})
+    assert result.failed == 0
 
 
 def test_observables():


### PR DESCRIPTION
Follow-up to #3818.

## Summary

- Fix signal docstring examples to import `ObservableSignals`.
- Replace weakly referenced inline lambdas with named handlers.
- Define handlers for the string-based compatibility examples.
- Add isolated doctest coverage for the signal type docstrings.

