### PR TITLE
Fix NumpyAgentDataSet agent ids becoming floats after storage expansion

### DIFF
--- a/mesa/experimental/data_collection/dataset.py
+++ b/mesa/experimental/data_collection/dataset.py
@@ -380,9 +380,9 @@ class NumpyAgentDataSet[A: Agent]:
         new_data[:current_size] = self._agent_data
         self._agent_data = new_data
 
-        new_data = np.zeros(new_size, dtype=self.dtype)
-        new_data[:current_size] = self._agent_ids
-        self._agent_ids = new_data
+        new_ids = np.zeros(new_size, dtype=int)
+        new_ids[:current_size] = self._agent_ids
+        self._agent_ids = new_ids
 
         # Reinstall properties to capture new array reference
         self._install_properties()

--- a/tests/experimental/test_dataset.py
+++ b/tests/experimental/test_dataset.py
@@ -329,6 +329,14 @@ def test_numpy_agent_dataset_expand_storage():
     for i in range(20):
         assert dataset.data[i, 0] == float(i)
 
+    # Agent ids must stay integer-typed after expansion, independent of the data
+    # dtype. Regression: expansion previously recreated _agent_ids with the data
+    # dtype (here float), silently turning agent ids into floats.
+    assert np.issubdtype(dataset._agent_ids.dtype, np.integer)
+    assert list(dataset.agent_ids) == [
+        agent.unique_id for agent in dataset.active_agents
+    ]
+
 
 def test_numpy_agent_dataset_property_cleanup_on_close():
     """Test that properties are removed from agent class on close."""


### PR DESCRIPTION
## Summary

`NumpyAgentDataSet._agent_ids` is created as an integer array in `__init__` (`np.zeros(n, dtype=int)`), but `_expand_storage` recreated it with `dtype=self.dtype` (the *data* dtype, `float64` by default). So once a dataset grows past its initial capacity `n`, agent unique ids are silently stored and returned as floats.

## Reproduce

```python
from mesa import Model, Agent

class MyAgent(Agent):
    pass

m = Model()
ds = m.data_registry.track_agents_numpy(MyAgent, "test", fields=["x"], n=2)
[MyAgent(m) for _ in range(5)]   # grows past n=2 -> triggers _expand_storage

print(ds._agent_ids.dtype)   # float64  (was int64 before expansion)
print(ds.agent_ids)          # [1. 2. 3. 4. 5.]  instead of [1 2 3 4 5]
```

## Fix

Recreate `_agent_ids` with `dtype=int` on expansion, matching `__init__`. Agent ids stay integers regardless of the data dtype.

## Test

Extended `test_numpy_agent_dataset_expand_storage` (which already uses `dtype=float` and exercises expansion, but never checked the id dtype) to assert `_agent_ids` stays integer-typed and the ids are correct after expansion.

Verified locally: full suite passes (760), ruff check and format clean.
