### PR TITLE
refactor(examples): migrate visualization apps to SpaceRenderer.render() (#3282)

### DIFF
--- a/mesa/examples/advanced/epstein_civil_violence/app.py
+++ b/mesa/examples/advanced/epstein_civil_violence/app.py
@@ -76,11 +76,11 @@ chart_component = make_plot_component(
 )
 
 epstein_model = EpsteinCivilViolence()
-renderer = SpaceRenderer(epstein_model, backend="matplotlib").setup_agents(
-    citizen_cop_portrayal
+renderer = (
+    SpaceRenderer(epstein_model, backend="matplotlib")
+    .setup_agents(citizen_cop_portrayal)
+    .render()
 )
-# Specifically, avoid drawing the grid to hide the grid lines.
-renderer.draw_agents()
 renderer.post_process = post_process
 
 page = SolaraViz(

--- a/mesa/examples/advanced/epstein_civil_violence/app.py
+++ b/mesa/examples/advanced/epstein_civil_violence/app.py
@@ -76,11 +76,10 @@ chart_component = make_plot_component(
 )
 
 epstein_model = EpsteinCivilViolence()
-renderer = (
-    SpaceRenderer(epstein_model, backend="matplotlib")
-    .setup_agents(citizen_cop_portrayal)
-    .render()
+renderer = SpaceRenderer(epstein_model, backend="matplotlib").setup_agents(
+    citizen_cop_portrayal
 )
+renderer.render()
 renderer.post_process = post_process
 
 page = SolaraViz(

--- a/mesa/examples/advanced/sugarscape_g1mt/app.py
+++ b/mesa/examples/advanced/sugarscape_g1mt/app.py
@@ -61,8 +61,8 @@ renderer = (
     SpaceRenderer(model, backend="altair")
     .setup_agents(agent_portrayal)
     .setup_property_layer(property_layer_portrayal)
-    .render()
 )
+renderer.render()
 
 renderer.post_process = post_process
 

--- a/mesa/examples/advanced/sugarscape_g1mt/app.py
+++ b/mesa/examples/advanced/sugarscape_g1mt/app.py
@@ -61,10 +61,8 @@ renderer = (
     SpaceRenderer(model, backend="altair")
     .setup_agents(agent_portrayal)
     .setup_property_layer(property_layer_portrayal)
+    .render()
 )
-# Specifically, avoid drawing the grid to hide the grid lines.
-renderer.draw_agents()
-renderer.draw_property_layer()
 
 renderer.post_process = post_process
 

--- a/mesa/examples/advanced/wolf_sheep/app.py
+++ b/mesa/examples/advanced/wolf_sheep/app.py
@@ -78,12 +78,8 @@ lineplot_component = make_plot_component(
 )
 
 model = WolfSheep(scenario=WolfSheepScenario(grass=True))
-
 renderer = (
-    SpaceRenderer(
-        model,
-        backend="matplotlib",
-    )
+    SpaceRenderer(model, backend="matplotlib")
     .setup_agents(wolf_sheep_portrayal)
     .render()
 )

--- a/mesa/examples/advanced/wolf_sheep/app.py
+++ b/mesa/examples/advanced/wolf_sheep/app.py
@@ -78,11 +78,8 @@ lineplot_component = make_plot_component(
 )
 
 model = WolfSheep(scenario=WolfSheepScenario(grass=True))
-renderer = (
-    SpaceRenderer(model, backend="matplotlib")
-    .setup_agents(wolf_sheep_portrayal)
-    .render()
-)
+renderer = SpaceRenderer(model, backend="matplotlib").setup_agents(wolf_sheep_portrayal)
+renderer.render()
 renderer.post_process = post_process_space
 
 page = SolaraViz(

--- a/mesa/examples/advanced/wolf_sheep/app.py
+++ b/mesa/examples/advanced/wolf_sheep/app.py
@@ -79,12 +79,15 @@ lineplot_component = make_plot_component(
 
 model = WolfSheep(scenario=WolfSheepScenario(grass=True))
 
-renderer = SpaceRenderer(
-    model,
-    backend="matplotlib",
-).setup_agents(wolf_sheep_portrayal)
+renderer = (
+    SpaceRenderer(
+        model,
+        backend="matplotlib",
+    )
+    .setup_agents(wolf_sheep_portrayal)
+    .render()
+)
 renderer.post_process = post_process_space
-renderer.draw_agents()
 
 page = SolaraViz(
     model,

--- a/mesa/examples/basic/conways_game_of_life/app.py
+++ b/mesa/examples/basic/conways_game_of_life/app.py
@@ -55,9 +55,8 @@ model_params = {
 # Create initial model instance
 model1 = ConwaysGameOfLife()
 
-renderer = (
-    SpaceRenderer(model1, backend="matplotlib").setup_agents(agent_portrayal).render()
-)
+renderer = SpaceRenderer(model1, backend="matplotlib").setup_agents(agent_portrayal)
+renderer.render()
 renderer.post_process = post_process
 
 # Create the SolaraViz page. This will automatically create a server and display the

--- a/mesa/examples/basic/conways_game_of_life/app.py
+++ b/mesa/examples/basic/conways_game_of_life/app.py
@@ -55,10 +55,9 @@ model_params = {
 # Create initial model instance
 model1 = ConwaysGameOfLife()
 
-renderer = SpaceRenderer(model1, backend="matplotlib").setup_agents(agent_portrayal)
-# In this case the renderer only draws the agents because we just want to observe
-# the state of the agents, not the structure of the grid.
-renderer.draw_agents()
+renderer = (
+    SpaceRenderer(model1, backend="matplotlib").setup_agents(agent_portrayal).render()
+)
 renderer.post_process = post_process
 
 # Create the SolaraViz page. This will automatically create a server and display the


### PR DESCRIPTION
### Pre-PR Checklist
- [x] I linked an issue/discussion where a maintainer approved this enhancement/feature for implementation.

### Summary
Migrates the visualization apps (`app.py`) in 4 core example models from deprecated manual drawing calls (`draw_agents()`, `draw_property_layer()`) to the modern, unified `SpaceRenderer.render()` API.

Fixes #3282.

### Motive
Several core examples in `mesa/examples` still called deprecated methods, producing `FutureWarning` and `PendingDeprecationWarning` when launching the models and creating a disconnect with modern tutorials.

### Implementation
Updated the visualization pipelines across 4 example apps to use method-chained `.render()`:
- `mesa/examples/basic/conways_game_of_life/app.py`: Chained `.render()` with `setup_agents()`.
- `mesa/examples/advanced/wolf_sheep/app.py`: Chained `.render()` with `setup_agents()`.
- `mesa/examples/advanced/sugarscape_g1mt/app.py`: Chained `.render()` with `setup_agents()` and `setup_property_layer()`.
- `mesa/examples/advanced/epstein_civil_violence/app.py`: Chained `.render()` with `setup_agents()`.
- Removed obsolete comments referring to manual step-by-step drawing.

### Testing
- `pytest tests/examples/test_examples.py` (14/14 passed)
- `pytest tests/visualization/test_space_renderer.py` & `test_solara_viz.py` (27/27 passed)
- Full test suite passed (760 tests passed)
- Verified with `-W error` that importing the apps produces zero deprecation warnings
- Passed `ruff check` and `ruff format`

### Additional Notes
This aligns the remaining core examples with the canonical pattern already established in `schelling`, `boid_flockers`, and `boltzmann_wealth_model`.
