### PR TITLE
fix(discrete_space): guard cell removal in FixedAgent.remove() when cell is None

### DIFF
--- a/mesa/discrete_space/cell_agent.py
+++ b/mesa/discrete_space/cell_agent.py
@@ -115,8 +115,9 @@ class FixedAgent(Agent, FixedCell):
         """Remove the agent from the model."""
         super().remove()
 
-        self.cell.remove_agent(self)
-        self._mesa_cell = None
+        if self._mesa_cell is not None:
+            self._mesa_cell.remove_agent(self)
+            self._mesa_cell = None
 
 
 class Grid2DMovingAgent(CellAgent):

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -346,4 +346,3 @@ def test_fixed_agent_remove_without_cell():
     assert agent in model.agents
     agent.remove()
     assert agent not in model.agents
-

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -335,3 +335,15 @@ def test_agent_advance_is_noop():
     model = Model()
     agent = AgentTest(model)
     assert agent.advance() is None
+
+
+def test_fixed_agent_remove_without_cell():
+    """Test that FixedAgent.remove() succeeds when the agent has no cell."""
+    from mesa.discrete_space import FixedAgent
+
+    model = Model()
+    agent = FixedAgent(model)
+    assert agent in model.agents
+    agent.remove()
+    assert agent not in model.agents
+


### PR DESCRIPTION
## Description
`FixedAgent.remove()` raised an `AttributeError` when the agent had not been assigned to a cell (`self.cell is None`), because it called `self.cell.remove_agent(self)` unconditionally. This caused `Model.remove_all_agents()` to crash whenever unplaced `FixedAgent` instances existed.

## Solution
Added a guard in `FixedAgent.remove()` to check if `self._mesa_cell is not None` before invoking `remove_agent()`, mirroring `CellAgent.remove()`. Added a unit test verifying clean removal of unplaced `FixedAgent` instances.

Fixes #3748