### PR TITLE
Fix FixedAgent.remove for unplaced agents

### DIFF
--- a/mesa/discrete_space/cell_agent.py
+++ b/mesa/discrete_space/cell_agent.py
@@ -115,8 +115,9 @@ class FixedAgent(Agent, FixedCell):
         """Remove the agent from the model."""
         super().remove()
 
-        self.cell.remove_agent(self)
-        self._mesa_cell = None
+        if self._mesa_cell is not None:
+            self._mesa_cell.remove_agent(self)
+            self._mesa_cell = None
 
 
 class Grid2DMovingAgent(CellAgent):

--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -1252,6 +1252,35 @@ def test_fixed_agent_removal_state():
     assert agent.cell is None
 
 
+def test_fixed_agent_removal_without_cell():
+    """Test that an unplaced FixedAgent can be removed. See #3748."""
+    model = Model()
+    agent = FixedAgent(model)
+
+    assert agent.cell is None
+
+    agent.remove()
+
+    assert agent.cell is None
+    assert agent not in model._all_agents
+
+
+def test_remove_all_agents_with_unplaced_fixed_agent():
+    """Test that remove_all_agents works with a mix of placed and unplaced agents."""
+    model = Model()
+    cell = Cell((1,), capacity=None, random=random.Random())
+    placed = FixedAgent(model)
+    placed.cell = cell
+    unplaced = FixedAgent(model)
+
+    model.remove_all_agents()
+
+    assert len(model._all_agents) == 0
+    assert placed not in cell.agents
+    assert placed.cell is None
+    assert unplaced.cell is None
+
+
 def test_pickling_cell():
     """Test pickling of a Cell."""
     cell = Cell((1,), capacity=1, random=random.Random(42))


### PR DESCRIPTION
### Pre-PR Checklist
- [x] This PR is a bug fix, not a new feature or enhancement.

### Summary

`FixedAgent.remove()` crashes with an `AttributeError` when the agent was never placed on a cell. Because `Model.remove_all_agents()` calls `agent.remove()` for every agent, a single unplaced `FixedAgent` anywhere in the model takes down the entire teardown.

### Bug / Issue

Fixes #3748.

`HasCell._mesa_cell` defaults to `None`, so a `FixedAgent` can exist without ever being assigned a cell. `FixedAgent.remove()` then dereferences that `None`:

```python
from mesa import Model
from mesa.discrete_space import FixedAgent

model = Model(rng=1)
agent = FixedAgent(model)
agent.remove()
```

```
AttributeError: 'NoneType' object has no attribute 'remove_agent'
```

Same crash via the model:

```python
model = Model(rng=1)
FixedAgent(model)
model.remove_all_agents()   # AttributeError
```

`CellAgent.remove()` is not affected — it assigns `self.cell = None`, and the `HasCell.cell` setter already null-checks the old cell. So the two agent classes behave inconsistently for the same operation.

### Implementation

Guard the cell cleanup on `_mesa_cell` being set, in `mesa/discrete_space/cell_agent.py`:

```diff
     def remove(self):
         """Remove the agent from the model."""
         super().remove()
 
-        self.cell.remove_agent(self)
-        self._mesa_cell = None
+        if self._mesa_cell is not None:
+            self._mesa_cell.remove_agent(self)
+            self._mesa_cell = None
```

Two lines, no behavioural change for placed agents: they are still detached from their cell and still have `_mesa_cell` reset. This mirrors what `CellAgent.remove()` achieves through the setter.

### Testing

Two regression tests added to `tests/discrete_space/test_discrete_space.py`, next to the existing `test_fixed_agent_removal_state`:

- `test_fixed_agent_removal_without_cell` — an unplaced agent removes cleanly, `cell` stays `None`, and the agent leaves `model._all_agents`.
- `test_remove_all_agents_with_unplaced_fixed_agent` — a model holding one placed and one unplaced `FixedAgent` tears down completely, and the placed agent is still detached from its cell.

Both fail on `main` with the `AttributeError` above (verified by reverting only the source change) and pass with the fix.

```
$ pytest tests/discrete_space/test_discrete_space.py -k "fixed_agent or patch or remove_all" -rA
4 passed, 89 deselected in 8.00s
    test_patch
    test_fixed_agent_removal_state
    test_fixed_agent_removal_without_cell
    test_remove_all_agents_with_unplaced_fixed_agent

$ pytest tests/discrete_space
102 passed in 14.54s

$ pytest tests --ignore=tests/examples
1 failed, 767 passed in 63.06s
```

The single failure is `tests/test_import_namespace.py::test_meta_agents` (`DID NOT RAISE ModuleNotFoundError`). It is pre-existing and unrelated — it fails the same way on a clean checkout of `main` with these changes stashed.

`ruff check` and `ruff format --check` pass on both changed files.

### Additional Notes

The existing tests `test_patch` and `test_fixed_agent_removal_state` already cover removal of a *placed* `FixedAgent`; they are untouched and still pass, which is what guarantees the guard did not change the placed-agent path.

An alternative would be to make `FixedAgent.remove()` delegate to the `cell` setter the way `CellAgent` does, but `FixedCell.cell` deliberately raises `ValueError` on reassignment, so the explicit `_mesa_cell` handling has to stay. Happy to reshape it if maintainers prefer a different structure.
