### PR TITLE
Make create_agents raise on length-mismatched sequences

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -129,17 +129,19 @@ class Agent[M: Model]:
             AgentSet containing the agents created.
 
         Warning:
-            A list, tuple, ndarray, or pandas Series argument whose length
-            equals n is always treated as one value per agent, even if you
-            intended it as a single shared value. This is especially easy
-            to hit with coordinate tuples: create_agents(model, 2, pos=(10,
-            20)) does NOT give both agents pos=(10, 20); it gives agent 0
-            pos=10 and agent 1 pos=20, since the tuple's length (2) matches
-            n (2).
+            A list, tuple, ndarray, or pandas Series argument is treated as one
+            value per agent and must have length n; a length mismatch raises
+            ValueError. This is especially easy to hit with coordinate tuples:
+            create_agents(model, 2, pos=(10, 20)) does NOT give both agents
+            pos=(10, 20); it gives agent 0 pos=10 and agent 1 pos=20, since the
+            tuple's length (2) matches n (2).
 
-            To share a value across all agents regardless of its length,
-            wrap it so its own length no longer matches n, e.g.:
+            To assign the same sequence value to every agent, broadcast it
+            explicitly as a length-n list of that value, e.g.:
             create_agents(model, 2, pos=[(10, 20)] * 2)
+
+        Raises:
+            ValueError: If a sequence argument's length does not match n.
 
         """
         agents = []
@@ -149,16 +151,13 @@ class Agent[M: Model]:
                 agents.append(cls(model))
             return AgentSet(agents, random=model.random)
 
-        # Prepare positional argument iterators. A sequence of length n is
-        # assigned per agent; anything else is broadcast (strict=False keeps the
-        # existing behavior where a mismatched-length sequence is broadcast whole).
-        arg_iters = [_resolve_per_agent_values(arg, n, strict=False) for arg in args]
+        # Prepare positional argument iterators. A sequence must have length n
+        # (assigned per agent); a length mismatch raises. Anything else is broadcast.
+        arg_iters = [_resolve_per_agent_values(arg, n) for arg in args]
 
         # Prepare keyword argument iterators
         kw_keys = list(kwargs.keys())
-        kw_val_iters = [
-            _resolve_per_agent_values(v, n, strict=False) for v in kwargs.values()
-        ]
+        kw_val_iters = [_resolve_per_agent_values(v, n) for v in kwargs.values()]
 
         # If arg_iters is empty, zip(*[]) returns nothing, so we use repeat(())
         pos_iter = zip(*arg_iters) if arg_iters else itertools.repeat(())

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -95,12 +95,11 @@ def test_agent_create_with_pandas():
     for i, agent in enumerate(agents):
         assert agent.kw_series_attr == kw_series_data.iloc[i]
 
-    # Test pandas Series with length mismatch
+    # A sequence whose length does not match n now raises instead of
+    # broadcasting the whole sequence to every agent.
     short_series = pd.Series([1, 2])  # length 2, but n=5
-    agents = TestAgent.create_agents(model, n, short_series)
-    for agent in agents:
-        # Should repeat the entire series, not individual elements
-        assert agent.series_attr.equals(short_series)
+    with pytest.raises(ValueError, match="does not match the number of agents"):
+        TestAgent.create_agents(model, n, short_series)
 
 
 def test_agent_from_dataframe():


### PR DESCRIPTION
Follow-up to #3817 (step 2 of the plan there). Switches `create_agents` onto the shared `_resolve_per_agent_values` helper with `strict=True`, so it now raises `ValueError` on a length-mismatched sequence argument instead of silently broadcasting the whole sequence to every agent. This aligns `create_agents` with `AgentSet.set`, which already raises.

Behavior change (documented in the docstring, release-note-worthy):
- `create_agents(model, n, seq)` where `len(seq) != n` now raises `ValueError` instead of broadcasting `seq` to every agent.

As expected from the discussion on #3817, this breaks the VirusAntibody example in mesa-examples (it passes a length-3 vector to broadcast across 20 agents). Per the break-here-fix-there workflow, a matching mesa-examples PR follows to fix it (broadcasting the vector explicitly as `[vec] * n`, which works under both the old and new behavior).

Verified locally: core suite passes, ruff check and format clean. The `build / examples` check will be red until the mesa-examples fix lands.
