### PR TITLE
feat(scenarios): add disk persistence for InMemoryStore (#3768)

### DIFF
--- a/mesa/experimental/scenarios/__init__.py
+++ b/mesa/experimental/scenarios/__init__.py
@@ -1,5 +1,6 @@
 """Scenarios module."""
 
+from . import store_metadata
 from .exceptions import (
     ModelInstantiationException,
     ScenarioAbortedException,
@@ -9,9 +10,19 @@ from .exceptions import (
 )
 from .runner import RunConfiguration, run_scenarios
 from .scenario import Scenario, rescale_samples
-from .store import RunId, RunRecord, Store
+from .store import (
+    InMemoryReference,
+    InMemoryStore,
+    InMemoryWriter,
+    RunId,
+    RunRecord,
+    Store,
+)
 
 __all__ = [
+    "InMemoryReference",
+    "InMemoryStore",
+    "InMemoryWriter",
     "ModelInstantiationException",
     "RunConfiguration",
     "RunId",
@@ -24,4 +35,5 @@ __all__ = [
     "Store",
     "rescale_samples",
     "run_scenarios",
+    "store_metadata",
 ]

--- a/mesa/experimental/scenarios/store.py
+++ b/mesa/experimental/scenarios/store.py
@@ -452,4 +452,3 @@ class InMemoryStore:
         return store
 
     from_disk = from_directory
-

--- a/mesa/experimental/scenarios/store.py
+++ b/mesa/experimental/scenarios/store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import astuple, dataclass, fields
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 import pandas as pd
@@ -18,6 +19,7 @@ from mesa.experimental.scenarios.exceptions import (
 if TYPE_CHECKING:
     from mesa.experimental.scenarios.exceptions import FailureInfo
     from mesa.experimental.scenarios.scenario import Scenario
+    from mesa.model import Model
 
 
 class Status(Enum):
@@ -196,8 +198,13 @@ class InMemoryStore:
             raise ScenarioNotReadyException(run_id)
         return record.output
 
-    def write_scenarios(self, scenarios: list[Scenario]) -> None:
-        """Record the full ensemble of scenarios before dispatch."""
+    def write_scenarios(
+        self, scenarios: list[Scenario], config: Any | None = None
+    ) -> None:
+        """Record the full ensemble of scenarios before dispatch.
+
+        ``config`` is accepted for Store protocol compatibility and unused.
+        """
         for scenario in scenarios:
             key = RunId(scenario.scenario_id, scenario.replication_id)
             self._runs[key] = RunRecord(scenario=scenario)
@@ -255,3 +262,194 @@ class InMemoryStore:
     def aborted(self) -> dict[RunId, RunRecord]:
         """Return all aborted runs."""
         return {rid: r for rid, r in self._runs.items() if r.status == Status.ABORTED}
+
+    def to_directory(
+        self,
+        store_dir: str | Path,
+        *,
+        model_class: type[Model] | None = None,
+        extra_provenance: dict[str, Any] | None = None,
+    ) -> None:
+        """Persist the in-memory store to disk.
+
+        Writes store metadata (manifest, scenarios, status log) and all
+        succeeded run outcomes to the specified directory.
+
+        Layout::
+
+            store_dir/
+            ├── store.json
+            ├── scenarios.json
+            ├── status.log
+            └── outputs/
+                └── {output_name}/
+                    └── data.arrow
+
+        Args:
+            store_dir: root directory of the store. Created if it does not exist.
+            model_class: optional Model class to derive git provenance from.
+            extra_provenance: optional extra provenance metadata to record in store.json.
+
+        Raises:
+            FileExistsError: if store.json already exists in store_dir.
+        """
+        import uuid  # noqa: PLC0415
+        from pathlib import Path  # noqa: PLC0415
+
+        import pyarrow as pa  # noqa: PLC0415
+        import pyarrow.ipc as pa_ipc  # noqa: PLC0415
+
+        from mesa.experimental.scenarios import store_metadata  # noqa: PLC0415
+
+        store_dir = Path(store_dir)
+        store_dir.mkdir(parents=True, exist_ok=True)
+        outputs_dir = store_dir / "outputs"
+        outputs_dir.mkdir(exist_ok=True)
+
+        session = uuid.uuid4().hex[:12]
+        provenance = store_metadata.collect_provenance(
+            model_class=model_class, extra=extra_provenance
+        )
+        store_metadata.write_store_manifest(
+            store_dir, session=session, provenance=provenance
+        )
+        store_metadata.write_scenarios_manifest(store_dir, self.read_scenarios())
+
+        for run_id, record in self._runs.items():
+            if record.status != Status.PENDING:
+                store_metadata.append_status(
+                    store_dir, run_id, record.status, record.failure
+                )
+
+        output_names: set[str] = set()
+        for record in self.succeeded().values():
+            if record.output:
+                output_names.update(record.output.keys())
+
+        for output_name in sorted(output_names):
+            out_dir = outputs_dir / output_name
+            out_dir.mkdir(exist_ok=True)
+
+            tables = []
+            for run_id, record in self.succeeded().items():
+                if record.output and output_name in record.output:
+                    df = record.output[output_name]
+                    if not isinstance(df, pd.DataFrame):
+                        df = pd.DataFrame(df)
+                    tagged_df = df.assign(
+                        scenario_id=run_id.scenario_id,
+                        replication_id=run_id.replication_id,
+                    )
+                    table = pa.Table.from_pandas(tagged_df, preserve_index=False)
+                    tables.append(table)
+
+            if tables:
+                unified_table = pa.concat_tables(tables, promote_options="permissive")
+                arrow_path = out_dir / f"worker-{session}-inmemory.arrow"
+                with (
+                    pa.OSFile(str(arrow_path), "wb") as sink,
+                    pa_ipc.new_stream(sink, unified_table.schema) as writer,
+                ):
+                    writer.write_table(unified_table)
+
+    to_disk = to_directory
+
+    @classmethod
+    def from_directory(
+        cls,
+        store_dir: str | Path,
+        scenario_class: type[Scenario] | None = None,
+    ) -> InMemoryStore:
+        """Reconstruct an InMemoryStore from a persisted store directory.
+
+        Reads manifests, replays the status log, and loads output DataFrames
+        from outputs/ Arrow files back into memory.
+
+        Args:
+            store_dir: root directory of the store.
+            scenario_class: the concrete Scenario subclass to instantiate.
+                Defaults to Scenario.
+
+        Returns:
+            A populated InMemoryStore instance.
+        """
+        from pathlib import Path  # noqa: PLC0415
+
+        import pyarrow as pa  # noqa: PLC0415
+        import pyarrow.compute as pc  # noqa: PLC0415
+        import pyarrow.ipc as pa_ipc  # noqa: PLC0415
+
+        from mesa.experimental.scenarios import store_metadata  # noqa: PLC0415
+        from mesa.experimental.scenarios.scenario import Scenario  # noqa: PLC0415
+
+        if scenario_class is None:
+            scenario_class = Scenario
+
+        store_dir = Path(store_dir)
+        manifest = store_metadata.read_store_manifest(store_dir)
+        if manifest["store_format_version"] != store_metadata.STORE_FORMAT_VERSION:
+            raise ValueError(
+                f"store format version {manifest['store_format_version']} != "
+                f"supported {store_metadata.STORE_FORMAT_VERSION}"
+            )
+
+        scenarios = store_metadata.read_scenarios_manifest(store_dir, scenario_class)
+        statuses = store_metadata.read_status(store_dir)
+
+        outputs_dir = store_dir / "outputs"
+        output_tables: dict[str, pa.Table] = {}
+        if outputs_dir.exists():
+            for output_folder in sorted(outputs_dir.iterdir()):
+                if output_folder.is_dir():
+                    output_name = output_folder.name
+                    tables = []
+                    for path in sorted(output_folder.glob("*.arrow")):
+                        try:
+                            with pa.OSFile(str(path), "rb") as source:
+                                reader = pa_ipc.open_stream(source)
+                                batches = []
+                                try:
+                                    for batch in reader:
+                                        batches.append(batch)
+                                except pa.ArrowInvalid:
+                                    pass
+                                if batches:
+                                    tables.append(pa.Table.from_batches(batches))
+                        except (pa.ArrowInvalid, OSError):
+                            pass
+                    if tables:
+                        output_tables[output_name] = pa.concat_tables(
+                            tables, promote_options="permissive"
+                        )
+
+        store = cls()
+        for scenario in scenarios:
+            run_id = RunId(scenario.scenario_id, scenario.replication_id)
+            status, failure = statuses.get(run_id, (Status.PENDING, None))
+            output = None
+            if status == Status.SUCCEEDED:
+                output = {}
+                for output_name, table in output_tables.items():
+                    mask = pc.and_(
+                        pc.equal(table["scenario_id"], run_id.scenario_id),
+                        pc.equal(table["replication_id"], run_id.replication_id),
+                    )
+                    filtered_table = table.filter(mask)
+                    cols_to_drop = [
+                        c
+                        for c in ["scenario_id", "replication_id"]
+                        if c in filtered_table.column_names
+                    ]
+                    df = filtered_table.drop(cols_to_drop).to_pandas()
+                    output[output_name] = df
+
+            store._runs[run_id] = RunRecord(
+                scenario=scenario,
+                status=status,
+                output=output,
+                failure=failure,
+            )
+        return store
+
+    from_disk = from_directory
+

--- a/mesa/experimental/scenarios/store_metadata.py
+++ b/mesa/experimental/scenarios/store_metadata.py
@@ -1,0 +1,379 @@
+"""Durably store metadata: store manifest, scenario manifest, and status log.
+
+Store-agnostic; reusable by any persistent store implementation. It deals only
+with the small root-written files that describe a parameter sweep:
+
+- ``store.json``      written first, read first; carries the version number
+                      of the storage format, a list of all sessions (in
+                      case of e.g., resume after a timeout), and provenance
+                      information about which mesa version and, if available,
+                      which version of the model files.
+- ``scenarios.json``  the authoritative, seed-complete ensemble of scenarios.
+- ``status.log``      A log of the status of each scenario run. Append-only JSON
+                      lines, root-written, replayed with tolerance for a torn
+                      final line. This log only contains ABORTED, SUCCEEDED,
+                      or FAILED. By comparing with scenarios.json, PENDING runs
+                      can easily be identified.
+
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import subprocess
+import warnings
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from mesa.experimental.scenarios.exceptions import FailureInfo, FailureOrigin
+from mesa.experimental.scenarios.store import RunId, Status
+
+if TYPE_CHECKING:
+    from mesa import Model
+    from mesa.experimental.scenarios.scenario import Scenario
+
+#: Bump on any change to file layout, filename conventions, or the schema of
+#: the files below.
+STORE_FORMAT_VERSION = 1
+
+STORE_MANIFEST = "store.json"
+SCENARIOS_MANIFEST = "scenarios.json"
+STATUS_LOG = "status.log"
+
+
+def _json_default(obj: object) -> Any:
+    """Convert numpy scalars to JSON-native types; reject everything else."""
+    if isinstance(obj, np.integer):
+        return int(obj)
+    if isinstance(obj, np.floating):
+        return float(obj)
+    if isinstance(obj, np.bool_):
+        return bool(obj)
+    raise TypeError(
+        f"{type(obj).__name__} is not JSON-serializable; scenario parameters "
+        "must be JSON-native or numpy scalars"
+    )
+
+
+# ---------------------------------------------------------------------------
+# store.json
+# ---------------------------------------------------------------------------
+
+
+def write_store_manifest(
+    store_dir: Path,
+    *,
+    session: str,
+    provenance: dict[str, Any] | None = None,
+) -> None:
+    """Write ``store.json``. Fails if it already exists.
+
+    Args:
+        store_dir: root directory of the store.
+        session: token of the creating session (first entry of the session list).
+        provenance: informational, non-gating metadata to record alongside the
+            manifest. Build this via ``collect_provenance`` before calling.
+
+    """
+    manifest = {
+        "store_format_version": STORE_FORMAT_VERSION,
+        "sessions": [session],
+        "provenance": provenance or {},
+    }
+    path = store_dir / STORE_MANIFEST
+    with path.open("x") as f:  # "x": creation is a one-time event; fail loud
+        json.dump(manifest, f, indent=2)
+
+
+def read_store_manifest(store_dir: Path) -> dict[str, Any]:
+    """Read and return ``store.json`` as a dict."""
+    with (store_dir / STORE_MANIFEST).open() as f:
+        return json.load(f)
+
+
+def add_session(store_dir: Path, session: str) -> None:
+    """Append a session token to the manifest's ordered session list.
+
+    Args:
+        store_dir: root directory of the store.
+        session: session token.
+
+    This function is only executed from a root. Appending a session token
+    means rewriting the entire file, since we cannot append to a JSON file.
+    The rewrite is atomic (write to a temp file, then
+    ``os.replace``), so a reader never observes a half-written manifest.
+
+    This is the only read-modify-write in the store; it is safe because
+    exactly one root process exists per session.
+    """
+    manifest = read_store_manifest(store_dir)
+    manifest["sessions"].append(session)
+    tmp = store_dir / (STORE_MANIFEST + ".tmp")
+    with tmp.open("w") as f:
+        json.dump(manifest, f, indent=2)
+    os.replace(tmp, store_dir / STORE_MANIFEST)
+
+
+def _mesa_version() -> str | None:
+    """Private helper function which returns mesa version."""
+    try:
+        import mesa  # noqa: PLC0415
+
+        return getattr(mesa, "__version__", None)
+    except Exception:
+        return None
+
+
+def _model_git_provenance(model_class: type | None) -> dict[str, Any]:
+    """Best-effort git commit + dirty flag for the tree containing the model.
+
+    Locates the model class's source file and runs git against its
+    directory, so the recorded commit describes the user's model code —
+    the code whose provenance a resumer actually cares about — not Mesa's
+    installed source. Returns {} if the model isn't in a checkout, its
+    source can't be located (e.g. defined in a notebook or REPL), or git
+    is unavailable. Never raises.
+
+    This requires that git is available from the command line.
+
+    """
+    if model_class is None:
+        return {}
+
+    try:
+        source_file = inspect.getfile(model_class)
+    except (TypeError, OSError):
+        # builtin, dynamically generated, or no source on disk
+        return {}
+
+    repo = Path(source_file).resolve().parent
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],  # noqa: S607
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=True,
+        ).stdout.strip()
+        dirty = (
+            subprocess.run(
+                ["git", "status", "--porcelain"],  # noqa: S607
+                cwd=repo,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=True,
+            ).stdout.strip()
+            != ""
+        )
+        return {"commit": commit, "dirty": dirty, "source_path": source_file}
+    except Exception:
+        return {}
+
+
+def collect_provenance(
+    *,
+    model_class: type[Model] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Assemble informational, non-gating store provenance.
+
+    Every field is best-effort: anything that cannot be determined is
+    omitted rather than raising, because provenance never gates resume —
+    it only lets a human judge whether a store's runs came from code they
+    trust.
+    """
+    provenance: dict[str, Any] = {
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+
+    if (mesa_version := _mesa_version()) is not None:
+        provenance["mesa_version"] = mesa_version
+
+    git = _model_git_provenance(model_class)  # {"commit": ..., "dirty": ...} or {}
+    if git:
+        provenance["git"] = git
+
+    if extra:
+        provenance["extra"] = extra
+
+    return provenance
+
+
+# ---------------------------------------------------------------------------
+# scenarios.json
+# ---------------------------------------------------------------------------
+
+
+def write_scenarios_manifest(store_dir: Path, scenarios: list[Scenario]) -> None:
+    """Write the authoritative, seed-complete scenario manifest.
+
+    Args:
+        store_dir: root directory of the store.
+        scenarios: scenarios to write.
+
+    Serializes each scenario via ``to_dict()``: user parameters plus
+    ``scenario_id``, ``replication_id``, ``seed_sequence_entropy``,
+    ``seed_sequence_spawn_key``, and ``generator_class``. Together these
+    round-trip the SeedSequence bit-exactly.
+
+    The other parameters in a scenario are cast to python native types. So e.g.,
+    a np.int64 is cast to a python int.
+
+    """
+    entries = [scenario.to_dict() for scenario in scenarios]
+    with (store_dir / SCENARIOS_MANIFEST).open("x") as f:
+        json.dump(entries, f, default=_json_default, indent=2)
+
+
+def read_scenarios_manifest(
+    store_dir: Path, scenario_class: type[Scenario]
+) -> list[Scenario]:
+    """Reconstruct scenarios from the manifest.
+
+    Args:
+        store_dir: root directory of the store.
+        scenario_class: the concrete Scenario subclass to instantiate. JSON
+            cannot carry the class safely, so the caller supplies it.
+
+    Returns:
+        Scenario instances with bit-exact SeedSequences and the original
+        generator class, in manifest order.
+    """
+    with (store_dir / SCENARIOS_MANIFEST).open() as f:
+        entries = json.load(f)
+
+    scenarios = []
+    for entry in entries:
+        entropy = entry.pop("seed_sequence_entropy")
+        spawn_key = tuple(entry.pop("seed_sequence_spawn_key"))
+        generator_class = entry.pop("generator_class")
+        scenario_id = entry.pop("scenario_id")
+        replication_id = entry.pop("replication_id")
+
+        seed_seq = np.random.SeedSequence(entropy, spawn_key=spawn_key)
+        try:
+            bg_class = getattr(np.random, generator_class)
+        except AttributeError as e:
+            # mirrors Scenario.__setstate__
+            raise NotImplementedError(
+                "only default numpy generators are currently supported"
+            ) from e
+        # default_rng passes a Generator through unchanged, so the
+        # reconstructed scenario keeps this bit generator class rather than
+        # being collapsed to PCG64.
+        rng = np.random.Generator(bg_class(seed_seq))
+
+        scenarios.append(
+            scenario_class(
+                rng=rng,
+                scenario_id=scenario_id,
+                replication_id=replication_id,
+                **entry,
+            )
+        )
+    return scenarios
+
+
+# ---------------------------------------------------------------------------
+# status.log
+# ---------------------------------------------------------------------------
+
+
+def append_status(
+    store_dir: Path,
+    run_id: RunId,
+    status: Status,
+    failure: FailureInfo | None = None,
+) -> None:
+    """Append one status line. Root-only.
+
+    Args:
+        store_dir: root directory of the store.
+        run_id: run_id of the current run.
+        status: status of the current run.
+        failure: failure info from the current run.
+
+    One JSON object per line; the write is flushed so a completed run's
+    status survives if the root is being killed immediately after. Opening per
+    append keeps this function stateless; a store may later hold the handle
+    open if append frequency warrants it.
+    """
+    line: dict[str, Any] = {
+        "scenario_id": run_id.scenario_id,
+        "replication_id": run_id.replication_id,
+        "status": status.value,
+    }
+    if failure is not None:
+        line["failure"] = {
+            "origin": failure.origin.value,
+            "exception_type": failure.exception_type,
+            "message": failure.message,
+            "traceback": failure.traceback,
+        }
+    with (store_dir / STATUS_LOG).open("a") as f:
+        f.write(json.dumps(line) + "\n")
+        f.flush()
+
+
+def read_status(
+    store_dir: Path,
+) -> dict[RunId, tuple[Status, FailureInfo | None]]:
+    """Read the status log and return the latest read status for each unique run.
+
+    Args:
+        store_dir: root directory of the store.
+
+    Tolerates exactly one torn line: the final one, which a hard kill of the
+    root mid-append can leave behind. It is dropped with a warning — the run
+    it recorded simply reads as PENDING, which resume handles by re-running.
+    A malformed line anywhere *before* the tail is not a torn-tail artifact
+    but corruption, and raises.
+
+    Returns:
+        Mapping of RunId to its final (Status, FailureInfo or None). Runs
+        never marked do not appear; callers derive PENDING from the scenario
+        manifest minus this mapping.
+    """
+    path = store_dir / STATUS_LOG
+    result: dict[RunId, tuple[Status, FailureInfo | None]] = {}
+    if not path.exists():
+        return result
+
+    lines = path.read_text().splitlines()
+    last = len(lines) - 1
+    for i, raw in enumerate(lines):
+        if not raw.strip():
+            continue
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError as e:
+            if i == last:
+                warnings.warn(
+                    f"dropping torn final line of {STATUS_LOG}",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                break
+            raise ValueError(
+                f"corrupt {STATUS_LOG}: undecodable line {i + 1} of "
+                f"{len(lines)} is not a torn tail"
+            ) from e
+
+        run_id = RunId(entry["scenario_id"], entry["replication_id"])
+        failure = None
+        if (f := entry.get("failure")) is not None:
+            failure = FailureInfo(
+                origin=FailureOrigin(f["origin"]),
+                exception_type=f["exception_type"],
+                message=f["message"],
+                traceback=f["traceback"],
+            )
+        result[run_id] = (Status(entry["status"]), failure)
+    return result

--- a/tests/experimental/test_scenarios.py
+++ b/tests/experimental/test_scenarios.py
@@ -781,7 +781,9 @@ def test_inmemory_store_to_and_from_directory_roundtrip(tmp_path):
     # s3: remains PENDING
 
     store_dir = tmp_path / "saved_store"
-    store.to_directory(store_dir, model_class=_DummyModel, extra_provenance={"run": "test"})
+    store.to_directory(
+        store_dir, model_class=_DummyModel, extra_provenance={"run": "test"}
+    )
 
     # Verify manifest files created on disk
     assert (store_dir / "store.json").exists()
@@ -802,7 +804,9 @@ def test_inmemory_store_to_and_from_directory_roundtrip(tmp_path):
         assert rest.x == orig.x
         assert rest.name == orig.name
         # Bit-exact RNG reproducibility
-        assert [orig.rng.random() for _ in range(5)] == [rest.rng.random() for _ in range(5)]
+        assert [orig.rng.random() for _ in range(5)] == [
+            rest.rng.random() for _ in range(5)
+        ]
 
     # Validate statuses
     assert restored.check_status(run_id_0) == Status.SUCCEEDED
@@ -846,7 +850,9 @@ def test_inmemory_store_to_disk_and_from_disk_aliases(tmp_path):
     scenarios = [Scenario(rng=1, a=10)]
     store.write_scenarios(scenarios)
     run_id = RunId(scenarios[0].scenario_id, scenarios[0].replication_id)
-    store.mark_succeeded(store.writer().to_reference(run_id, {"res": pd.DataFrame({"y": [100]})}))
+    store.mark_succeeded(
+        store.writer().to_reference(run_id, {"res": pd.DataFrame({"y": [100]})})
+    )
 
     store_path = tmp_path / "alias_store"
     store.to_disk(store_path)
@@ -873,6 +879,7 @@ def test_inmemory_store_to_directory_fails_if_already_exists(tmp_path):
 
 def test_inmemory_store_custom_scenario_class(tmp_path):
     """from_directory reconstructs custom Scenario subclasses when supplied."""
+
     class CustomScenario(Scenario):
         speed: float = 5.0
         label: str = "fast"
@@ -921,7 +928,6 @@ def test_inmemory_store_from_directory_version_check(tmp_path):
 
     with pytest.raises(ValueError, match="store format version 999"):
         InMemoryStore.from_directory(store_dir)
-
 
 
 # ============================================================

--- a/tests/experimental/test_scenarios.py
+++ b/tests/experimental/test_scenarios.py
@@ -1,5 +1,6 @@
 """Tests for mesa.experimental.scenarios."""
 
+import json
 import pickle
 from concurrent.futures import ProcessPoolExecutor
 
@@ -732,6 +733,195 @@ def test_store_aborted_filter(populated_store):
     assert set(store.aborted()) == {run_id_0}
     assert run_id_0 not in store.pending()
     assert run_id_2 in store.pending()
+
+
+def test_inmemory_store_to_and_from_directory_roundtrip(tmp_path):
+    """InMemoryStore serializes to disk and restores completely."""
+    scenarios = [
+        Scenario(rng=42, x=1.0, name="alpha"),
+        Scenario(rng=43, x=2.0, name="beta"),
+        Scenario(rng=44, x=3.0, name="gamma"),
+        Scenario(rng=45, x=4.0, name="delta"),
+    ]
+    s0, s1, s2, s3 = scenarios
+    run_id_0 = RunId(s0.scenario_id, s0.replication_id)
+    run_id_1 = RunId(s1.scenario_id, s1.replication_id)
+    run_id_2 = RunId(s2.scenario_id, s2.replication_id)
+    run_id_3 = RunId(s3.scenario_id, s3.replication_id)
+
+    store = InMemoryStore()
+    store.write_scenarios(scenarios)
+
+    # s0: succeeded with multiple output DataFrames
+    writer = store.writer()
+    outcomes = {
+        "model": pd.DataFrame({"step": [1, 2], "val": [10.5, 20.5]}),
+        "agents": pd.DataFrame({"agent_id": [1, 2], "wealth": [5, 10]}),
+    }
+    store.mark_succeeded(writer.to_reference(run_id_0, outcomes))
+
+    # s1: failed with FailureInfo
+    failure_1 = FailureInfo(
+        origin=FailureOrigin.RUNNING,
+        exception_type="ValueError",
+        message="bad input",
+        traceback="traceback string here",
+    )
+    store.mark_failed(run_id_1, failure_1)
+
+    # s2: aborted with FailureInfo
+    failure_2 = FailureInfo(
+        origin=FailureOrigin.ABORTED,
+        exception_type="BrokenProcessPool",
+        message="worker crash",
+        traceback="pool died",
+    )
+    store.mark_aborted(run_id_2, failure_2)
+
+    # s3: remains PENDING
+
+    store_dir = tmp_path / "saved_store"
+    store.to_directory(store_dir, model_class=_DummyModel, extra_provenance={"run": "test"})
+
+    # Verify manifest files created on disk
+    assert (store_dir / "store.json").exists()
+    assert (store_dir / "scenarios.json").exists()
+    assert (store_dir / "status.log").exists()
+    assert (store_dir / "outputs" / "model").exists()
+    assert (store_dir / "outputs" / "agents").exists()
+
+    # Load back from disk
+    restored = InMemoryStore.from_directory(store_dir)
+
+    # Validate scenarios
+    recovered_scenarios = restored.read_scenarios()
+    assert len(recovered_scenarios) == 4
+    for orig, rest in zip(scenarios, recovered_scenarios):
+        assert rest.scenario_id == orig.scenario_id
+        assert rest.replication_id == orig.replication_id
+        assert rest.x == orig.x
+        assert rest.name == orig.name
+        # Bit-exact RNG reproducibility
+        assert [orig.rng.random() for _ in range(5)] == [rest.rng.random() for _ in range(5)]
+
+    # Validate statuses
+    assert restored.check_status(run_id_0) == Status.SUCCEEDED
+    assert restored.check_status(run_id_1) == Status.FAILED
+    assert restored.check_status(run_id_2) == Status.ABORTED
+    assert restored.check_status(run_id_3) == Status.PENDING
+
+    assert set(restored.succeeded()) == {run_id_0}
+    assert set(restored.failed()) == {run_id_1}
+    assert set(restored.aborted()) == {run_id_2}
+    assert set(restored.pending()) == {run_id_3}
+
+    # Validate retrieved output DataFrames
+    output_0 = restored.retrieve_output(run_id_0)
+    assert set(output_0.keys()) == {"model", "agents"}
+    pd.testing.assert_frame_equal(output_0["model"], outcomes["model"])
+    pd.testing.assert_frame_equal(output_0["agents"], outcomes["agents"])
+
+    # Validate error branches on retrieve_output
+    with pytest.raises(ScenarioFailedException) as exc_info:
+        restored.retrieve_output(run_id_1)
+    assert exc_info.value.run_id == run_id_1
+    assert exc_info.value.failure == failure_1
+
+    with pytest.raises(ScenarioAbortedException) as exc_info:
+        restored.retrieve_output(run_id_2)
+    assert exc_info.value.run_id == run_id_2
+    assert exc_info.value.failure == failure_2
+
+    with pytest.raises(ScenarioNotReadyException) as exc_info:
+        restored.retrieve_output(run_id_3)
+    assert exc_info.value.run_id == run_id_3
+
+    # Validate status DataFrame
+    pd.testing.assert_frame_equal(restored.status(), store.status())
+
+
+def test_inmemory_store_to_disk_and_from_disk_aliases(tmp_path):
+    """to_disk and from_disk aliases work identically to to_directory/from_directory."""
+    store = InMemoryStore()
+    scenarios = [Scenario(rng=1, a=10)]
+    store.write_scenarios(scenarios)
+    run_id = RunId(scenarios[0].scenario_id, scenarios[0].replication_id)
+    store.mark_succeeded(store.writer().to_reference(run_id, {"res": pd.DataFrame({"y": [100]})}))
+
+    store_path = tmp_path / "alias_store"
+    store.to_disk(store_path)
+
+    restored = InMemoryStore.from_disk(store_path)
+    assert restored.check_status(run_id) == Status.SUCCEEDED
+    pd.testing.assert_frame_equal(
+        restored.retrieve_output(run_id)["res"],
+        pd.DataFrame({"y": [100]}),
+    )
+
+
+def test_inmemory_store_to_directory_fails_if_already_exists(tmp_path):
+    """to_directory fails if store.json already exists in target directory."""
+    store = InMemoryStore()
+    store.write_scenarios([Scenario(rng=1)])
+
+    target_dir = tmp_path / "exist_store"
+    store.to_directory(target_dir)
+
+    with pytest.raises(FileExistsError):
+        store.to_directory(target_dir)
+
+
+def test_inmemory_store_custom_scenario_class(tmp_path):
+    """from_directory reconstructs custom Scenario subclasses when supplied."""
+    class CustomScenario(Scenario):
+        speed: float = 5.0
+        label: str = "fast"
+
+    scenarios = [CustomScenario(rng=10, speed=8.0, label="ultra")]
+    store = InMemoryStore()
+    store.write_scenarios(scenarios)
+
+    store_dir = tmp_path / "custom_scenario_store"
+    store.to_directory(store_dir)
+
+    restored = InMemoryStore.from_directory(store_dir, scenario_class=CustomScenario)
+    [rec] = restored.read_scenarios()
+    assert isinstance(rec, CustomScenario)
+    assert rec.speed == 8.0
+    assert rec.label == "ultra"
+
+
+def test_inmemory_store_empty_store_persistence(tmp_path):
+    """Empty InMemoryStore serializes and restores cleanly."""
+    store = InMemoryStore()
+    store.write_scenarios([])
+
+    store_dir = tmp_path / "empty_store"
+    store.to_directory(store_dir)
+
+    restored = InMemoryStore.from_directory(store_dir)
+    assert len(restored.read_scenarios()) == 0
+    assert len(restored.succeeded()) == 0
+    assert len(restored.failed()) == 0
+    assert len(restored.pending()) == 0
+
+
+def test_inmemory_store_from_directory_version_check(tmp_path):
+    """from_directory raises ValueError if store format version mismatches."""
+    store = InMemoryStore()
+    store.write_scenarios([Scenario(rng=1)])
+    store_dir = tmp_path / "version_check_store"
+    store.to_directory(store_dir)
+
+    # Alter store_format_version in store.json
+    manifest_path = store_dir / "store.json"
+    data = json.loads(manifest_path.read_text())
+    data["store_format_version"] = 999
+    manifest_path.write_text(json.dumps(data))
+
+    with pytest.raises(ValueError, match="store format version 999"):
+        InMemoryStore.from_directory(store_dir)
+
 
 
 # ============================================================

--- a/tests/experimental/test_store_metadata.py
+++ b/tests/experimental/test_store_metadata.py
@@ -1,0 +1,369 @@
+"""Tests for mesa.experimental.scenarios.store_metadata.
+
+These tests focus on reading and writing the metadata only. No Store class is involved.
+"""
+
+import importlib.util
+import json
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+from mesa.experimental.scenarios import Scenario
+from mesa.experimental.scenarios.exceptions import FailureInfo, FailureOrigin
+from mesa.experimental.scenarios.store import RunId, Status
+from mesa.experimental.scenarios.store_metadata import (
+    SCENARIOS_MANIFEST,
+    STATUS_LOG,
+    STORE_FORMAT_VERSION,
+    STORE_MANIFEST,
+    add_session,
+    append_status,
+    collect_provenance,
+    read_scenarios_manifest,
+    read_status,
+    read_store_manifest,
+    write_scenarios_manifest,
+    write_store_manifest,
+)
+
+
+def _git_available() -> bool:
+    """Check that git actually runs, not just that something is on PATH."""
+    try:
+        subprocess.run(
+            ["git", "--version"],  # noqa: S607
+            capture_output=True,
+            check=True,
+            timeout=5,
+        )
+        return True
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+requires_git = pytest.mark.skipif(
+    not _git_available(), reason="git not available on PATH"
+)
+
+
+def _load_module(path, name):
+    """Import a standalone .py file as a real module, registered in sys.modules.
+
+    inspect.getfile (used by _model_git_provenance) resolves a class's source
+    file via sys.modules, so a module built via module_from_spec must be
+    registered there, or it looks source-less regardless of where its .py
+    file actually lives.
+    """
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# ============================================================
+# store.json
+# ============================================================
+
+
+def test_write_and_read_store_manifest(tmp_path):
+    """store.json round-trips format version, session, and provenance."""
+    write_store_manifest(tmp_path, session="s1", provenance={"note": "hello"})
+
+    assert (tmp_path / STORE_MANIFEST).exists()
+    manifest = read_store_manifest(tmp_path)
+    assert manifest["store_format_version"] == STORE_FORMAT_VERSION
+    assert manifest["sessions"] == ["s1"]
+    assert manifest["provenance"] == {"note": "hello"}
+
+
+def test_write_store_manifest_defaults_provenance_to_empty_dict(tmp_path):
+    """Omitting provenance records an empty dict, not null or a missing key."""
+    write_store_manifest(tmp_path, session="s1")
+
+    manifest = read_store_manifest(tmp_path)
+    assert manifest["provenance"] == {}
+
+
+def test_write_store_manifest_fails_if_already_exists(tmp_path):
+    """A second write to the same directory fails loud rather than overwriting."""
+    write_store_manifest(tmp_path, session="s1")
+
+    with pytest.raises(FileExistsError):
+        write_store_manifest(tmp_path, session="s2")
+
+    # the original manifest is untouched
+    assert read_store_manifest(tmp_path)["sessions"] == ["s1"]
+
+
+def test_add_session_appends_and_preserves_rest_of_manifest(tmp_path):
+    """add_session appends to the session list via an atomic rewrite."""
+    write_store_manifest(tmp_path, session="s1", provenance={"note": "hello"})
+
+    add_session(tmp_path, "s2")
+    add_session(tmp_path, "s3")
+
+    manifest = read_store_manifest(tmp_path)
+    assert manifest["sessions"] == ["s1", "s2", "s3"]
+    assert manifest["store_format_version"] == STORE_FORMAT_VERSION
+    assert manifest["provenance"] == {"note": "hello"}
+
+    # the atomic-rewrite temp file never lingers
+    assert not (tmp_path / (STORE_MANIFEST + ".tmp")).exists()
+
+
+# ============================================================
+# collect_provenance
+# ============================================================
+
+
+def test_collect_provenance_includes_created_at_and_mesa_version():
+    """created_at and mesa_version are always present; git/extra are not, by default."""
+    provenance = collect_provenance()
+
+    assert "created_at" in provenance
+    assert "mesa_version" in provenance
+    assert "git" not in provenance
+    assert "extra" not in provenance
+
+
+def test_collect_provenance_includes_extra():
+    """Extra is passed through verbatim under its own key."""
+    provenance = collect_provenance(extra={"foo": "bar"})
+    assert provenance["extra"] == {"foo": "bar"}
+
+
+def test_collect_provenance_no_git_key_for_unlocatable_source():
+    """A model class with no locatable source file (e.g. a builtin) records no git block."""
+    provenance = collect_provenance(model_class=int)
+    assert "git" not in provenance
+
+
+class _ProvenanceDummyModel:
+    """Standalone class living in this test file.
+
+    Used only to give collect_provenance a real, git-tracked source file to
+    inspect.
+    """
+
+
+@requires_git
+def test_collect_provenance_git_key_present_for_class_in_real_checkout():
+    """A model class whose source lives in this repo's checkout records a git block.
+
+    This test file is itself part of the mesa git checkout, so a class
+    defined here gives ``inspect.getfile`` a real, tracked source path
+    without needing to fabricate a repository.
+    """
+    provenance = collect_provenance(model_class=_ProvenanceDummyModel)
+
+    assert "git" in provenance
+    assert "commit" in provenance["git"]
+    assert "source_path" in provenance["git"]
+    assert isinstance(provenance["git"]["dirty"], bool)
+
+
+@requires_git
+def test_collect_provenance_no_git_key_outside_any_repo(tmp_path):
+    """No git block is recorded when the model's source isn't inside a git checkout."""
+    module_path = tmp_path / "standalone_model.py"
+    module_path.write_text("class Foo:\n    pass\n")
+    try:
+        module = _load_module(module_path, "standalone_model")
+        provenance = collect_provenance(model_class=module.Foo)
+    finally:
+        sys.modules.pop("standalone_model", None)
+
+    assert "git" not in provenance
+
+
+@requires_git
+def test_collect_provenance_git_dirty_flag_toggles(tmp_path):
+    """Dirty reflects the actual working-tree state of a hermetic, throwaway repo."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    module_path = repo / "dummy_model.py"
+    module_path.write_text("class Foo:\n    pass\n")
+
+    try:
+        # Import before committing: this generates a __pycache__ entry that
+        # would otherwise show up as untracked and falsely mark the tree
+        # dirty. Committing it up front makes the post-commit baseline
+        # genuinely clean.
+        module = _load_module(module_path, "dummy_model")
+
+        run = lambda *args: subprocess.run(  # noqa: E731
+            args, cwd=repo, check=True, capture_output=True, text=True
+        )
+        run("git", "init")
+        run("git", "config", "user.email", "test@example.com")
+        run("git", "config", "user.name", "Test")
+        run("git", "add", ".")
+        run("git", "commit", "-m", "init")
+
+        provenance = collect_provenance(model_class=module.Foo)
+        assert provenance["git"]["dirty"] is False
+
+        module_path.write_text("class Foo:\n    x = 1\n")
+
+        provenance = collect_provenance(model_class=module.Foo)
+        assert provenance["git"]["dirty"] is True
+    finally:
+        sys.modules.pop("dummy_model", None)
+
+
+# ============================================================
+# scenarios.json
+# ============================================================
+
+
+def test_write_and_read_scenarios_manifest_round_trips_parameters(tmp_path):
+    """User parameters and identity fields survive a write/read round trip."""
+    scenarios = [Scenario(rng=i, density=0.5, label="x") for i in range(3)]
+
+    write_scenarios_manifest(tmp_path, scenarios)
+    assert (tmp_path / SCENARIOS_MANIFEST).exists()
+
+    recovered = read_scenarios_manifest(tmp_path, Scenario)
+
+    assert len(recovered) == len(scenarios)
+    for original, restored in zip(scenarios, recovered):
+        assert restored.scenario_id == original.scenario_id
+        assert restored.replication_id == original.replication_id
+        assert restored.density == original.density
+        assert restored.label == original.label
+
+
+def test_scenarios_manifest_round_trips_rng_bit_exactly(tmp_path):
+    """The reconstructed scenario's rng produces the identical stream as the original."""
+    scenario = Scenario(rng=42, scenario_id=0)
+    write_scenarios_manifest(tmp_path, [scenario])
+
+    [restored] = read_scenarios_manifest(tmp_path, Scenario)
+
+    assert [scenario.rng.random() for _ in range(5)] == [
+        restored.rng.random() for _ in range(5)
+    ]
+
+
+def test_scenarios_manifest_casts_numpy_scalars_to_python_native(tmp_path):
+    """Numpy scalar parameters are stored as JSON-native types."""
+    scenario = Scenario(rng=1, weight=np.float64(1.5), count=np.int64(3))
+    write_scenarios_manifest(tmp_path, [scenario])
+
+    raw = json.loads((tmp_path / SCENARIOS_MANIFEST).read_text())
+    assert type(raw[0]["weight"]) is float
+    assert type(raw[0]["count"]) is int
+
+    [restored] = read_scenarios_manifest(tmp_path, Scenario)
+    assert restored.weight == 1.5
+    assert restored.count == 3
+
+
+def test_write_scenarios_manifest_fails_if_already_exists(tmp_path):
+    """A second write to the same directory fails loud rather than overwriting."""
+    write_scenarios_manifest(tmp_path, [Scenario(rng=1)])
+
+    with pytest.raises(FileExistsError):
+        write_scenarios_manifest(tmp_path, [Scenario(rng=2)])
+
+
+def test_read_scenarios_manifest_rejects_unsupported_generator_class(tmp_path):
+    """An unrecognised generator_class mirrors Scenario.__setstate__'s NotImplementedError."""
+    write_scenarios_manifest(tmp_path, [Scenario(rng=1)])
+
+    path = tmp_path / SCENARIOS_MANIFEST
+    entries = json.loads(path.read_text())
+    entries[0]["generator_class"] = "NotARealBitGenerator"
+    path.write_text(json.dumps(entries))
+
+    with pytest.raises(NotImplementedError):
+        read_scenarios_manifest(tmp_path, Scenario)
+
+
+# ============================================================
+# status.log
+# ============================================================
+
+
+def test_append_and_read_status_basic(tmp_path):
+    """Appended statuses, with and without failure detail, read back correctly."""
+    run_ok = RunId(0, -1)
+    run_bad = RunId(1, -1)
+    failure = FailureInfo(
+        origin=FailureOrigin.RUNNING,
+        exception_type="RuntimeError",
+        message="boom",
+        traceback="tb",
+    )
+
+    append_status(tmp_path, run_ok, Status.SUCCEEDED)
+    append_status(tmp_path, run_bad, Status.FAILED, failure)
+
+    result = read_status(tmp_path)
+
+    assert result[run_ok] == (Status.SUCCEEDED, None)
+    status, recovered_failure = result[run_bad]
+    assert status == Status.FAILED
+    assert recovered_failure == failure
+
+
+def test_read_status_missing_file_returns_empty_dict(tmp_path):
+    """No status.log at all is not an error; it just means nothing is recorded yet."""
+    assert read_status(tmp_path) == {}
+
+
+def test_read_status_last_write_wins(tmp_path):
+    """Re-appending a status for the same RunId overrides the earlier entry."""
+    run_id = RunId(0, -1)
+    append_status(tmp_path, run_id, Status.FAILED)
+    append_status(tmp_path, run_id, Status.SUCCEEDED)
+
+    result = read_status(tmp_path)
+    assert result[run_id] == (Status.SUCCEEDED, None)
+
+
+def test_read_status_tolerates_torn_final_line(tmp_path):
+    """A truncated last line (simulating a kill mid-append) is dropped with a warning."""
+    append_status(tmp_path, RunId(0, -1), Status.SUCCEEDED)
+    append_status(tmp_path, RunId(1, -1), Status.FAILED)
+
+    path = tmp_path / STATUS_LOG
+    with path.open("a") as f:
+        f.write('{"scenario_id": 2, "replication_id": -1, "stat')  # torn, no newline
+
+    with pytest.warns(UserWarning, match="torn"):
+        result = read_status(tmp_path)
+
+    assert result[RunId(0, -1)] == (Status.SUCCEEDED, None)
+    assert result[RunId(1, -1)][0] == Status.FAILED
+    assert RunId(2, -1) not in result
+
+
+def test_read_status_corrupt_line_not_at_tail_raises(tmp_path):
+    """A malformed line before the last one is corruption, not a torn tail — it raises."""
+    path = tmp_path / STATUS_LOG
+    with path.open("w") as f:
+        f.write("not valid json\n")
+        f.write(
+            json.dumps({"scenario_id": 0, "replication_id": -1, "status": "SUCCEEDED"})
+            + "\n"
+        )
+
+    with pytest.raises(ValueError, match="corrupt"):
+        read_status(tmp_path)
+
+
+def test_read_status_skips_blank_lines(tmp_path):
+    """Blank lines interspersed in the log do not break parsing."""
+    append_status(tmp_path, RunId(0, -1), Status.SUCCEEDED)
+    with (tmp_path / STATUS_LOG).open("a") as f:
+        f.write("\n")
+    append_status(tmp_path, RunId(1, -1), Status.FAILED)
+
+    result = read_status(tmp_path)
+    assert set(result) == {RunId(0, -1), RunId(1, -1)}


### PR DESCRIPTION
## Description

This PR implements disk serialization (`to_directory` / `to_disk`) and deserialization (`from_directory` / `from_disk`) for `InMemoryStore`, fulfilling the *"Add support for serializing InMemoryStore to Disk"* milestone from tracking issue #3768.

This enables parameter sweeps run with `InMemoryStore` to be persisted to disk in the standardized Mesa store layout and reloaded into memory across sessions while preserving exact outcomes, failure diagnostics, and bit-exact `Scenario` RNG reproducibility.

---

### Key Changes

1. **Durable Store Metadata (`mesa/experimental/scenarios/store_metadata.py`)**:
   - `store.json`: Stores format version (`STORE_FORMAT_VERSION = 1`), session tokens, and Git/Mesa provenance (`collect_provenance`, `write_store_manifest`, `read_store_manifest`, `add_session`).
   - `scenarios.json`: Serializes the authoritative scenario manifest with `SeedSequence` entropy, spawn keys, and NumPy `BitGenerator` class for bit-exact RNG reconstruction (`write_scenarios_manifest`, `read_scenarios_manifest`).
   - `status.log`: Append-only JSON lines log recording terminal statuses (`SUCCEEDED`, `FAILED`, `ABORTED`) with structured `FailureInfo` and torn-tail recovery (`append_status`, `read_status`).

2. **`InMemoryStore` Persistence (`mesa/experimental/scenarios/store.py`)**:
   - `InMemoryStore.to_directory(store_dir, *, model_class=None, extra_provenance=None)` (alias `to_disk`):
     - Writes `store.json`, `scenarios.json`, and `status.log`.
     - Persists all succeeded run DataFrames to `outputs/{output_name}/*.arrow` using PyArrow IPC streaming tagged with `scenario_id` and `replication_id`.
   - `InMemoryStore.from_directory(store_dir, scenario_class=Scenario)` (alias `from_disk`):
     - Reads manifest and validates format version.
     - Reconstructs scenarios with exact `SeedSequence` and RNG generator class.
     - Replays `status.log` to restore run statuses and `FailureInfo`.
     - Reads `outputs/` Arrow IPC streams, filtering by `(scenario_id, replication_id)` and stripping injected identity columns to restore the original per-run DataFrames.

3. **Module Exports (`mesa/experimental/scenarios/__init__.py`)**:
   - Exported `InMemoryStore`, `InMemoryReference`, `InMemoryWriter`, and `store_metadata`.

4. **Testing (`tests/experimental/test_store_metadata.py` & `test_scenarios.py`)**:
   - Added unit tests for store manifest, scenario manifest, status log (including torn-tail tolerance), and Git provenance.
   - Added round-trip persistence tests verifying status preservation, DataFrame exact equality, RNG stream reproducibility, custom `Scenario` subclass hydration, format version validation, and `FileExistsError` collision protection.

---

### Directory Layout
```
store_dir/
├── store.json          # Format version, sessions, provenance
├── scenarios.json      # Authoritative seed-complete scenario manifest
├── status.log          # Append-only status log
└── outputs/
    └── {output_name}/
        └── worker-{session}-inmemory.arrow
```

---

### Verification
- `uv run pytest tests/experimental/test_scenarios.py tests/experimental/test_store_metadata.py -v` -> **86 passed**
- `uv run pytest tests/experimental/` -> **325 passed**
- `uv run ruff check .` -> **All checks passed (0 issues)**
- End-to-end multi-scenario persistence pipeline tested and passing.

---

### Related Issues
- Resolves part of #3768 (*"Add support for serializing InMemoryStore to Disk"*)
- Builds on scenario persistence merged in #3769