### PR TITLE
CI: Start testing Python 3.15

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.14'
+          python-version: '3.15'
       - name: Add project directory to PYTHONPATH
         run: echo "PYTHONPATH=$PYTHONPATH:$(pwd)" >> $GITHUB_ENV
       - name: Install uv

--- a/.github/workflows/build_lint.yml
+++ b/.github/workflows/build_lint.yml
@@ -28,15 +28,17 @@ jobs:
       fail-fast: False
       matrix:
         os: [windows, ubuntu, macos]
-        python-version: ["3.14"]
+        python-version: ["3.15"]
         pip-pre: [""]
         include:
+          - os: ubuntu
+            python-version: "3.14"
           - os: ubuntu
             python-version: "3.13"
           - os: ubuntu
             python-version: "3.12"
           - os: ubuntu
-            python-version: "3.14"
+            python-version: "3.15"
             pip-pre: "--pre"
           # Disabled for now. See https://github.com/mesa/mesa/issues/1253
           #- os: ubuntu
@@ -66,7 +68,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7
         with:
-          python-version: "3.14"
+          python-version: "3.15"
       - run: pip install uv
       - run: uv pip install --system .[dev]
       - run: playwright install chromium-headless-shell
@@ -83,7 +85,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.13"
+          python-version: "3.15"
           allow-prereleases: true
           cache: "pip"
       - name: Install uv

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.14"
+          python-version: "3.15"
           allow-prereleases: true
           cache: 'pip'
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Python has released it final 3.15 release candidate, 3.15.0rc2. This seems to be a good moment to see what breaks and what not. Most likely we will have some upstream dependencies who are not ready yet.

https://www.python.org/downloads/release/python-3150rc2/
