### PR TITLE
Add Agent.on_idle wake dispatched as a deferred low-priority event

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -17,8 +17,10 @@ import pandas as pd
 if TYPE_CHECKING:
     from mesa.experimental.actions import Action
     from mesa.model import Model
+    from mesa.time import Event
 
 from mesa.agentset import AgentSet, _resolve_per_agent_values
+from mesa.time import Priority
 
 
 class Agent[M: Model]:
@@ -65,6 +67,9 @@ class Agent[M: Model]:
         self.model: M = model
         self.unique_id = None
         self.current_action: Action | None = None
+        self._wake_event: Event | None = None
+        self._wake_previous: Action | None = None
+        self._last_wake_time: float = float("-inf")
         self.model.register_agent(self)
 
         for dataset in self._datasets:
@@ -77,7 +82,8 @@ class Agent[M: Model]:
         scheduled completion event is cancelled silently. The action's
         on_interrupt() callback is NOT fired, because the agent is being
         destroyed — not making a behavioral decision. The action moves
-        to no defined end state; it is simply abandoned.
+        to no defined end state; it is simply abandoned. A pending
+        on_idle wake is cancelled as well: a removed agent never wakes.
 
         If your action holds external resources (e.g., a Resource slot,
         a reservation, a lock), override Agent.remove() and call
@@ -97,6 +103,11 @@ class Agent[M: Model]:
         if self.current_action is not None:
             self.current_action._cancel_event()  # Silent cleanup, no callback
             self.current_action = None
+
+        if self._wake_event is not None:
+            self._wake_event.cancel()
+            self._wake_event = None
+            self._wake_previous = None
 
         with contextlib.suppress(KeyError):
             self.model.deregister_agent(self)
@@ -364,3 +375,56 @@ class Agent[M: Model]:
     def is_busy(self) -> bool:
         """Whether the agent is currently performing an action."""
         return self.current_action is not None
+
+    def on_idle(self, previous: Action | None) -> None:
+        """Called when the agent's action has ended and nothing replaced it.
+
+        Override it to choose what to do next, typically by starting or
+        resuming an action. The default does nothing, and nothing is
+        resumed automatically: an interrupted action stays interrupted
+        unless this hook (or other model code) restarts it.
+
+        Args:
+            previous: The action that just ended, in its final state
+                (COMPLETED, INTERRUPTED, or FAILED). None is reserved for
+                wakes not caused by an action ending; no built-in trigger
+                sends it today.
+
+        Notes:
+            At most one wake fires per agent per model time, so a
+            zero-duration action started here cannot re-trigger the hook
+            in the same instant. The wake is skipped when the agent is
+            busy again by the time the event runs -- interrupt_for()
+            refills the slot synchronously, so no idle gap ever existed.
+            If several actions end before the wake runs, they coalesce
+            into one call and ``previous`` is the latest of them.
+        """
+
+    def _schedule_wake(self, previous: Action | None) -> None:
+        """Queue the deferred on_idle event, coalescing repeats.
+
+        Called by Action._release_agent whenever this agent's slot is
+        cleared. If a wake is already pending, or one already fired at
+        the current model time, no second event is queued -- only
+        ``previous`` is brought up to date.
+        """
+        self._wake_previous = previous
+        if self._wake_event is not None:
+            return
+        if self._last_wake_time == self.model.time:
+            return
+        self._wake_event = self.model.schedule_event(
+            self._fire_wake, after=0.0, priority=Priority.LOW
+        )
+
+    def _fire_wake(self) -> None:
+        """Run the pending wake: call on_idle if the agent is still free."""
+        previous = self._wake_previous
+        self._wake_event = None
+        self._wake_previous = None
+        if self.current_action is not None:
+            return
+        # Recorded only when on_idle actually runs, so a busy skip does not
+        # suppress a later release at the same model time.
+        self._last_wake_time = self.model.time
+        self.on_idle(previous)

--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -20,7 +20,10 @@ if TYPE_CHECKING:
     from mesa.time import Event
 
 from mesa.agentset import AgentSet, _resolve_per_agent_values
+from mesa.mesa_logging import create_module_logger
 from mesa.time import Priority
+
+_mesa_logger = create_module_logger()
 
 
 class Agent[M: Model]:
@@ -393,7 +396,8 @@ class Agent[M: Model]:
         Notes:
             At most one wake fires per agent per model time, so a
             zero-duration action started here cannot re-trigger the hook
-            in the same instant. The wake is skipped when the agent is
+            in the same instant; a wake dropped by this guard is logged
+            at DEBUG level. The wake is skipped when the agent is
             busy again by the time the event runs -- interrupt_for()
             refills the slot synchronously, so no idle gap ever existed.
             If several actions end before the wake runs, they coalesce
@@ -406,12 +410,17 @@ class Agent[M: Model]:
         Called by Action._release_agent whenever this agent's slot is
         cleared. If a wake is already pending, or one already fired at
         the current model time, no second event is queued -- only
-        ``previous`` is brought up to date.
+        ``previous`` is brought up to date. A wake dropped by the
+        once-per-time guard is logged at DEBUG level.
         """
         self._wake_previous = previous
         if self._wake_event is not None:
             return
         if self._last_wake_time == self.model.time:
+            _mesa_logger.debug(
+                f"suppressed repeat on_idle wake for agent {self.unique_id} "
+                f"at time {self.model.time} (ending action: {previous!r})"
+            )
             return
         self._wake_event = self.model.schedule_event(
             self._fire_wake, after=0.0, priority=Priority.LOW

--- a/mesa/experimental/actions/actions.py
+++ b/mesa/experimental/actions/actions.py
@@ -5,7 +5,9 @@ Mesa's event scheduling system for precise timing and supports interruption
 with progress tracking and optional resumption.
 
 Actions are subclassable: override on_start(), on_complete(),
-on_interrupt(), and on_fail() to define behavior.
+on_interrupt(), and on_fail() to define behavior. When an action ends,
+the agent's Agent.on_idle() hook fires; decisions about what to do
+next -- chain another action, resume an interrupted one -- belong there.
 
 Example::
 
@@ -348,10 +350,7 @@ class Action:
         self._cancel_event()
 
         self.state = ActionState.INTERRUPTED
-
-        if self.agent.current_action is self:
-            self.agent.current_action = None
-
+        self._release_agent()
         self.on_interrupt(self._progress)
         return True
 
@@ -372,10 +371,7 @@ class Action:
         self._cancel_event()
 
         self.state = ActionState.INTERRUPTED
-
-        if self.agent.current_action is self:
-            self.agent.current_action = None
-
+        self._release_agent()
         self.on_interrupt(self._progress)
         return True
 
@@ -396,6 +392,20 @@ class Action:
         if self._event is not None:
             self._event.cancel()
             self._event = None
+
+    def _release_agent(self) -> None:
+        """Clear the agent's slot and schedule its idle wake.
+
+        Completion, interruption, cancellation, and failure all funnel
+        through here, so the wake contract has a single path. An action
+        that never held the slot (started directly, without
+        Agent.start_action) wakes nobody. Agent.remove() is the one end
+        that does not come through here: it abandons the action, and a
+        dying agent must not wake.
+        """
+        if self.agent.current_action is self:
+            self.agent.current_action = None
+            self.agent._schedule_wake(self)
 
     def _resolve_priority(self) -> None:
         """Resolve the priority spec against the agent, at most once.
@@ -421,10 +431,7 @@ class Action:
     def _fail(self) -> None:
         """Move to FAILED, release the agent, and fire on_fail()."""
         self.state = ActionState.FAILED
-
-        if self.agent.current_action is self:
-            self.agent.current_action = None
-
+        self._release_agent()
         self.on_fail()
 
     def _do_complete(self) -> None:
@@ -442,11 +449,7 @@ class Action:
             return
 
         self.state = ActionState.COMPLETED
-
-        # Clear agent's reference so it's no longer busy
-        if self.agent.current_action is self:
-            self.agent.current_action = None
-
+        self._release_agent()
         self.on_complete()
 
     def __repr__(self) -> str:

--- a/tests/experimental/test_actions.py
+++ b/tests/experimental/test_actions.py
@@ -875,13 +875,18 @@ class TestActionFailure:
         assert action.progress == 0.0
         assert not agent.is_busy
 
-    def test_start_failure_schedules_nothing(self):
+    def test_start_failure_schedules_no_completion(self):
         model, agent = make_model_and_agent()
         before = len(model._event_list)
 
-        agent.start_action(TrackedAction(agent, start_requirements=lambda a: False))
+        action = TrackedAction(agent, start_requirements=lambda a: False)
+        agent.start_action(action)
 
-        assert len(model._event_list) == before
+        # Exactly one new event: the agent's idle wake, never a completion.
+        assert len(model._event_list) == before + 1
+        model.run_for(10)
+        assert action.start_count == 0
+        assert not action.completed
 
     def test_failed_action_cannot_be_restarted(self):
         _model, agent = make_model_and_agent()
@@ -1305,3 +1310,172 @@ class TestRealisticScenarios:
 
         assert trade.state is ActionState.FAILED
         assert not trader.filled
+
+
+# --- Wake contract (on_idle) ---
+
+
+class IdleRecorder(Agent):
+    """Agent that records every on_idle wake with the state it saw."""
+
+    def __init__(self, model):
+        super().__init__(model)
+        self.wakes = []
+
+    def on_idle(self, previous):
+        state = previous.state if previous is not None else None
+        self.wakes.append((self.model.time, previous, state))
+
+
+class TestOnIdle:
+    def make_recorder(self):
+        model = Model()
+        return model, IdleRecorder(model)
+
+    def test_wake_fires_after_completion(self):
+        model, agent = self.make_recorder()
+        action = TrackedAction(agent, duration=5.0)
+        agent.start_action(action)
+
+        model.run_for(6)
+
+        assert agent.wakes == [(5.0, action, ActionState.COMPLETED)]
+
+    def test_wake_is_deferred_not_synchronous(self):
+        model, agent = self.make_recorder()
+        action = TrackedAction(agent)
+        agent.start_action(action)
+        agent.cancel_action()
+
+        # The release only queued the wake; nothing has fired yet.
+        assert agent.wakes == []
+
+        model.run_for(1)
+        assert agent.wakes == [(0.0, action, ActionState.INTERRUPTED)]
+
+    def test_wake_fires_for_interrupt(self):
+        model, agent = self.make_recorder()
+        action = TrackedAction(agent, duration=5.0)
+        agent.start_action(action)
+        model.run_for(2)
+
+        assert action.interrupt()
+        model.run_for(1)
+
+        assert agent.wakes == [(2.0, action, ActionState.INTERRUPTED)]
+
+    def test_wake_fires_for_start_failure(self):
+        model, agent = self.make_recorder()
+        action = TrackedAction(agent, start_requirements=lambda a: False)
+        agent.start_action(action)
+
+        model.run_for(1)
+
+        assert agent.wakes == [(0.0, action, ActionState.FAILED)]
+
+    def test_wake_fires_for_completion_failure(self):
+        model, agent = self.make_recorder()
+        action = TrackedAction(
+            agent, duration=3.0, completion_requirements=lambda a: False
+        )
+        agent.start_action(action)
+
+        model.run_for(4)
+
+        assert agent.wakes == [(3.0, action, ActionState.FAILED)]
+
+    def test_no_wake_when_interrupt_for_refills_the_slot(self):
+        model, agent = self.make_recorder()
+        first = TrackedAction(agent, duration=5.0, priority=1.0)
+        second = TrackedAction(agent, duration=3.0, priority=2.0)
+        agent.start_action(first)
+
+        assert agent.interrupt_for(second)
+        model.run_for(4)
+
+        # No idle gap ever existed at t=0; the only wake is second's end.
+        assert agent.wakes == [(3.0, second, ActionState.COMPLETED)]
+
+    def test_coalesced_wake_reports_latest_action(self):
+        model, agent = self.make_recorder()
+        first = TrackedAction(agent)
+        agent.start_action(first)
+        agent.cancel_action()
+        second = TrackedAction(agent, duration=0.0)
+        agent.start_action(second)  # completes instantly, wake still pending
+
+        model.run_for(1)
+
+        assert agent.wakes == [(0.0, second, ActionState.COMPLETED)]
+
+    def test_zero_duration_chain_wakes_once_per_time(self):
+        # Without the once-per-time guard this recurses forever: the test
+        # hangs rather than fails.
+        model = Model()
+
+        class Chain(Agent):
+            def __init__(self, model):
+                super().__init__(model)
+                self.idle_calls = 0
+
+            def on_idle(self, previous):
+                self.idle_calls += 1
+                self.start_action(Action(self, duration=0.0))
+
+        agent = Chain(model)
+        agent.start_action(Action(agent, duration=0.0))
+        model.run_for(1)
+
+        assert agent.idle_calls == 1
+
+    def test_agent_chains_actions_across_time(self):
+        model = Model()
+
+        class Worker(Agent):
+            def __init__(self, model):
+                super().__init__(model)
+                self.done = 0
+
+            def on_idle(self, previous):
+                self.done += 1
+                self.start_action(Action(self, duration=1.0))
+
+        agent = Worker(model)
+        agent.start_action(Action(agent, duration=1.0))
+        model.run_for(3.5)
+
+        # Completions at t=1, 2, 3; each wake starts the next task.
+        assert agent.done == 3
+
+    def test_wake_runs_after_all_completions_at_that_time(self):
+        model = Model()
+        observed = []
+        other = TrackedAction(Agent(model), duration=5.0)
+
+        class Nosy(Agent):
+            def on_idle(self, previous):
+                observed.append(other.state)
+
+        nosy = Nosy(model)
+        mine = TrackedAction(nosy, duration=5.0)
+        nosy.start_action(mine)
+        other.agent.start_action(other)
+
+        model.run_for(6)
+
+        # Both actions end at t=5. The wake is Priority.LOW, so it runs
+        # after the other agent's completion even though that completion
+        # was queued later.
+        assert observed == [ActionState.COMPLETED]
+
+    def test_remove_cancels_pending_wake(self):
+        model, agent = self.make_recorder()
+        action = TrackedAction(agent)
+        agent.start_action(action)
+        agent.cancel_action()
+
+        agent.remove()
+        model.run_for(1)
+
+        assert agent.wakes == []
+        assert agent._wake_event is None

--- a/tests/experimental/test_actions.py
+++ b/tests/experimental/test_actions.py
@@ -1,6 +1,8 @@
 """Tests for mesa.experimental.actions."""
 
 # ruff: noqa: D101, D102, D103, D107
+import logging
+
 import pytest
 
 from mesa import Agent, Model
@@ -1427,6 +1429,21 @@ class TestOnIdle:
         model.run_for(1)
 
         assert agent.idle_calls == 1
+
+    def test_suppressed_wake_is_logged_at_debug(self, caplog):
+        model = Model()
+
+        class Chain(Agent):
+            def on_idle(self, previous):
+                self.start_action(Action(self, duration=0.0))
+
+        agent = Chain(model)
+        agent.start_action(Action(agent, duration=0.0))
+        with caplog.at_level(logging.DEBUG, logger="MESA.mesa.agent"):
+            model.run_for(1)
+
+        assert "suppressed repeat on_idle wake" in caplog.text
+        assert f"agent {agent.unique_id}" in caplog.text
 
     def test_agent_chains_actions_across_time(self):
         model = Model()


### PR DESCRIPTION
### Summary
Adds `Agent.on_idle(previous)`: called whenever the agent's action has ended — completion, interruption, cancellation, or failure — and nothing has replaced it. Dispatched as a zero-delay `Priority.LOW` event. Completes section 3 of #3798.

### Motive
After #3801 and #3805 an action can fail or be preempted, but nothing tells the agent afterwards; models must poll or schedule around it. `on_idle` is the "body became free" half of the wake contract: one place to chain the next action or resume an interrupted one. The default is a no-op, and nothing is resumed automatically.

### Implementation
- Every ending funnels through a new `Action._release_agent()`, which clears the agent's slot and schedules the wake. `Agent.remove()` bypasses it and cancels a pending wake — a removed agent never wakes.
- Dispatch is deferred rather than synchronous from `_do_complete`: a zero-duration action started from `on_idle` cannot recurse, and every agent finishing at time *t* decides after all completions at *t* have run.
- At most one wake per agent per model time; endings that pile up coalesce, with `previous` reporting the latest. A wake that finds the agent busy again (`interrupt_for` refilled the slot synchronously) is skipped.
- Eleven new lifecycle tests (`TestOnIdle`); `test_start_failure_schedules_nothing` sharpened into `test_start_failure_schedules_no_completion`.

### Usage Examples
```python
class Worker(Agent):
    def on_idle(self, previous):
        self.start_action(Task(self, duration=1.0))
```
Each completion wakes the worker once, after all other completions at that time, and the next task begins, no external driver.

### Additional Notes
Docs and the task-driven example are section 5 of #3798 and follow separately. `on_idle` sits on `Agent` next to the existing action cluster, pending the mixin question raised in #3805.
