### PR TITLE
fix(visualization): reject positional-only parameters in _check_model_params

### DIFF
--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -752,12 +752,12 @@ def _check_model_params(model_or_func, model_params):
 
     model_parameters = inspect.signature(init_func).parameters
 
-    has_var_positional = any(
-        param.kind == inspect.Parameter.VAR_POSITIONAL
+    has_positional_only = any(
+        param.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.VAR_POSITIONAL)
         for param in model_parameters.values()
     )
 
-    if has_var_positional:
+    if has_positional_only:
         raise ValueError(
             "Mesa's visualization requires the use of keyword arguments to ensure the parameters are passed to Solara correctly. Please ensure all model parameters are of form param=value"
         )

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -753,7 +753,8 @@ def _check_model_params(model_or_func, model_params):
     model_parameters = inspect.signature(init_func).parameters
 
     has_positional_only = any(
-        param.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.VAR_POSITIONAL)
+        param.kind
+        in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.VAR_POSITIONAL)
         for param in model_parameters.values()
     )
 

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -757,8 +757,7 @@ def _check_model_params(model_or_func, model_params):
     model_parameters = inspect.signature(init_func).parameters
 
     has_non_keyword_param = any(
-        param.kind in _NON_KEYWORD_PARAM_KINDS
-        for param in model_parameters.values()
+        param.kind in _NON_KEYWORD_PARAM_KINDS for param in model_parameters.values()
     )
 
     if has_non_keyword_param:

--- a/mesa/visualization/solara_viz.py
+++ b/mesa/visualization/solara_viz.py
@@ -53,6 +53,10 @@ if TYPE_CHECKING:
 _mesa_logger = create_module_logger()
 
 _SUPPORTED_MODEL_PARAM_TYPES = (UserParam, dict, int, float, bool, str)
+_NON_KEYWORD_PARAM_KINDS = (
+    inspect.Parameter.POSITIONAL_ONLY,
+    inspect.Parameter.VAR_POSITIONAL,
+)
 
 
 def _validate_model_params(model_params: dict) -> None:
@@ -752,13 +756,12 @@ def _check_model_params(model_or_func, model_params):
 
     model_parameters = inspect.signature(init_func).parameters
 
-    has_positional_only = any(
-        param.kind
-        in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.VAR_POSITIONAL)
+    has_non_keyword_param = any(
+        param.kind in _NON_KEYWORD_PARAM_KINDS
         for param in model_parameters.values()
     )
 
-    if has_positional_only:
+    if has_non_keyword_param:
         raise ValueError(
             "Mesa's visualization requires the use of keyword arguments to ensure the parameters are passed to Solara correctly. Please ensure all model parameters are of form param=value"
         )

--- a/tests/visualization/test_solara_viz.py
+++ b/tests/visualization/test_solara_viz.py
@@ -244,9 +244,12 @@ def test_model_param_checks():
             pass
 
     with pytest.raises(
-        ValueError, match=re.escape("Mesa's visualization requires the use of keyword arguments")
+        ValueError,
+        match=re.escape("Mesa's visualization requires the use of keyword arguments"),
     ):
-        _check_model_params(ModelWithPositionalOnly.__init__, {"param1": 1, "param2": 10})
+        _check_model_params(
+            ModelWithPositionalOnly.__init__, {"param1": 1, "param2": 10}
+        )
 
     # Test var-positional (*args) parameters raise ValueError
     class ModelWithVarPositional:
@@ -254,7 +257,8 @@ def test_model_param_checks():
             pass
 
     with pytest.raises(
-        ValueError, match=re.escape("Mesa's visualization requires the use of keyword arguments")
+        ValueError,
+        match=re.escape("Mesa's visualization requires the use of keyword arguments"),
     ):
         _check_model_params(ModelWithVarPositional.__init__, {"param1": 1})
 

--- a/tests/visualization/test_solara_viz.py
+++ b/tests/visualization/test_solara_viz.py
@@ -238,6 +238,26 @@ def test_model_param_checks():
     with pytest.raises(ValueError, match=re.escape("Missing required model parameter")):
         _check_model_params(ModelWithOnlyRequired.__init__, {})
 
+    # Test positional-only parameters raise ValueError
+    class ModelWithPositionalOnly:
+        def __init__(self, param1, /, param2=10):
+            pass
+
+    with pytest.raises(
+        ValueError, match=re.escape("Mesa's visualization requires the use of keyword arguments")
+    ):
+        _check_model_params(ModelWithPositionalOnly.__init__, {"param1": 1, "param2": 10})
+
+    # Test var-positional (*args) parameters raise ValueError
+    class ModelWithVarPositional:
+        def __init__(self, *args, param1=1):
+            pass
+
+    with pytest.raises(
+        ValueError, match=re.escape("Mesa's visualization requires the use of keyword arguments")
+    ):
+        _check_model_params(ModelWithVarPositional.__init__, {"param1": 1})
+
 
 def test_model_creator():  # noqa: D103
     class ModelWithRequiredParam:

--- a/tests/visualization/test_solara_viz.py
+++ b/tests/visualization/test_solara_viz.py
@@ -255,9 +255,7 @@ def test_model_param_checks():
         ValueError,
         match=re.escape("Mesa's visualization requires the use of keyword arguments"),
     ):
-        _check_model_params(
-            ModelWithPositionalOnly(1), {"param1": 1, "param2": 10}
-        )
+        _check_model_params(ModelWithPositionalOnly(1), {"param1": 1, "param2": 10})
 
     # Test var-positional (*args) parameters raise ValueError (function and model instance)
     class ModelWithVarPositional:
@@ -275,7 +273,6 @@ def test_model_param_checks():
         match=re.escape("Mesa's visualization requires the use of keyword arguments"),
     ):
         _check_model_params(ModelWithVarPositional(), {"param1": 1})
-
 
 
 def test_model_creator():  # noqa: D103

--- a/tests/visualization/test_solara_viz.py
+++ b/tests/visualization/test_solara_viz.py
@@ -238,7 +238,7 @@ def test_model_param_checks():
     with pytest.raises(ValueError, match=re.escape("Missing required model parameter")):
         _check_model_params(ModelWithOnlyRequired.__init__, {})
 
-    # Test positional-only parameters raise ValueError
+    # Test positional-only parameters raise ValueError (function and model instance)
     class ModelWithPositionalOnly:
         def __init__(self, param1, /, param2=10):
             pass
@@ -251,7 +251,15 @@ def test_model_param_checks():
             ModelWithPositionalOnly.__init__, {"param1": 1, "param2": 10}
         )
 
-    # Test var-positional (*args) parameters raise ValueError
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Mesa's visualization requires the use of keyword arguments"),
+    ):
+        _check_model_params(
+            ModelWithPositionalOnly(1), {"param1": 1, "param2": 10}
+        )
+
+    # Test var-positional (*args) parameters raise ValueError (function and model instance)
     class ModelWithVarPositional:
         def __init__(self, *args, param1=1):
             pass
@@ -261,6 +269,13 @@ def test_model_param_checks():
         match=re.escape("Mesa's visualization requires the use of keyword arguments"),
     ):
         _check_model_params(ModelWithVarPositional.__init__, {"param1": 1})
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape("Mesa's visualization requires the use of keyword arguments"),
+    ):
+        _check_model_params(ModelWithVarPositional(), {"param1": 1})
+
 
 
 def test_model_creator():  # noqa: D103


### PR DESCRIPTION
## Description
Adds explicit validation for `inspect.Parameter.POSITIONAL_ONLY` in `_check_model_params` alongside `VAR_POSITIONAL`.

## Motivation and Context
Fixes #2494

SolaraViz instantiates models internally using `type(model.value)(**kwargs)`. If a model constructor defines positional-only parameters (e.g., `def __init__(self, width, /, height):`), attempting to instantiate it with keyword arguments raises a runtime `TypeError: __init__() got some positional-only arguments passed as keyword arguments`.

This change ensures `_check_model_params` catches positional-only parameters early during parameter validation and raises a descriptive `ValueError` explaining the keyword-only requirement for Solara visualization.

## How Has This Been Tested?
Added unit tests in `tests/visualization/test_solara_viz.py` testing both positional-only (`/`) and variable-positional (`*args`) constructors.