### PR TITLE
Adding model-introspection schema (Phase 1)

### DIFF
--- a/mesa/visualization/introspection.py
+++ b/mesa/visualization/introspection.py
@@ -1,0 +1,53 @@
+"""Machine-readable introspection of a Mesa model's structure.
+
+Defines a standardized, JSON-serializable description of a running Mesa
+model — its agent types, space, configurable parameters, and data-collection
+reporters — so external tools (including LLMs writing custom frontends or
+scaffolding new models) work from a stable contract instead of guessing at
+a model's shape from source code.
+
+See discussion #3832 for full context and open design questions.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from mesa.model import Model
+
+
+class ModelSchema(BaseModel):
+    """A JSON-serializable description of a Mesa model's structure.
+
+    Attributes:
+        agent_types: One entry per distinct agent class in the model,
+            describing its name and public attributes.
+        space: A description of the model's space, or None if the model
+            has no space.
+        params: The model's configurable parameters, as already defined
+            in model_params (Slider, Choice, etc.).
+        reporters: Names of the model's and agents' data-collector
+            reporters, if a DataRegistry is present.
+    """
+
+    agent_types: list[dict[str, Any]] = Field(default_factory=list)
+    space: dict[str, Any] | None = None
+    params: dict[str, Any] = Field(default_factory=dict)
+    reporters: dict[str, Any] = Field(default_factory=dict)
+
+
+def describe_model(model: "Model") -> ModelSchema:
+    """Produce a JSON-serializable schema describing a Mesa model.
+
+    Currently a skeleton: returns the contract's shape with nothing
+    populated. Each field is filled in by a following commit, so the
+    shape itself can be reviewed before logic is built on top of it.
+
+    Args:
+        model: A Mesa Model instance to describe.
+
+    Returns:
+        A ModelSchema with all fields at their empty defaults.
+    """
+    return ModelSchema()

--- a/tests/test_introspection.py
+++ b/tests/test_introspection.py
@@ -1,0 +1,27 @@
+"""Tests for mesa.visualization.introspection."""
+
+import unittest
+
+import mesa
+from mesa.visualization.introspection import ModelSchema, describe_model
+
+
+class MinimalModel(mesa.Model):
+    """Simplest possible model, used to test the empty schema shape."""
+
+
+class TestDescribeModel(unittest.TestCase):
+    """Tests for describe_model()'s empty-shape skeleton behavior."""
+
+    def test_returns_model_schema(self):
+        """describe_model() should return a ModelSchema instance."""
+        schema = describe_model(MinimalModel())
+        self.assertIsInstance(schema, ModelSchema)
+
+    def test_empty_shape_defaults(self):
+        """With no population logic yet, all fields should be empty."""
+        schema = describe_model(MinimalModel())
+        self.assertEqual(schema.agent_types, [])
+        self.assertIsNone(schema.space)
+        self.assertEqual(schema.params, {})
+        self.assertEqual(schema.reporters, {})


### PR DESCRIPTION
### Description
Relates to #3832. , so this is opened as a pathfinding PR — not merge-ready 

**Long-term plan** (full context in #3832)

Phases
1.Introspection contract — `describe_model()` schema, Commit 1
2.Transport layer — FastAPI + WebSocket server exposing the schema | Not started; separate commit once this shape settles
3.LLM context pipeline — schema + binding recipes handed to whichever LLM generates the frontend or scaffolds a model, Not started 

Phase 1 is scoped to stand on its own — it doesn't need Phases 2–3 to be useful (a stable schema has value even without a runtime server or an LLM pipeline consuming it yet), and keeping it self-contained means this PR can be reviewed without also having to settle the transport or LLM design.

**Suggested commit sequence**
1. `schema: add ModelSchema shape and describe_model( ) skeleton` — defines the output shape only, no population logic yet. **Updated per #3832:** a Pydantic `BaseModel`, not a plain dataclass — resolves the bespoke-vs- OpenAPI question as "both," since a Pydantic model is a bespoke shape *and* plugs into FastAPI/OpenAPI for free. One smoke test checking the empty shape. Smallest possible first review unit — start here.
2. `schema: populate agent_types from model.agents` — walks the AgentSet, collects distinct agent classes and their public attributes. Tests with 2-3 minimal agent classes.
3. `schema: populate params from model_params` — reuses SolaraViz's existing Slider/Choice objects rather than inventing new ones. Tests for both param types.
4. `schema: populate space from model.space / discrete_space` — covers OrthogonalGrid and ContinuousSpace to start; Network as a stretch goal, not a blocker. Tests per space type covered.
5. `schema: populate reporters from DataRegistry` — **updated per #3832:** targets the new `DataRegistry`/`CollectorListener` system directly rather than legacy `DataCollector`, per maintainer steer in the discussion. Means developing against the 4.0.0a0 alpha for this commit specifically — flag that plainly in the commit message and PR comment in case it needs to wait on a less-alpha DataRegistry.
6. `docs+example: document the contract, add a worked example` — a docs page plus `describe_model()` run against `boltzmann_wealth` or `schelling`, per CONTRIBUTING's expectation that new features are illustrated in an example.

**What this PR does**
- Adds `describe_model()` (`mesa.visualization.introspection`, or wherever the discussion lands) producing a JSON-serializable schema of a model's agent types, space, params, and DataCollector reporters.
- Reuses existing `agent_portrayal` / `model_params` conventions rather than introducing new ones.
- Adds unit tests per commit above.
- Adds one example under `mesa/examples` demonstrating the schema output.
- Adds a docs page explaining the contract, linked from the visualization docs.

**Explicitly out of scope (tracked separately)**
- The FastAPI/WebSocket runtime server (Phase 2).
- The LLM prompt/context pipeline (Phase 3).