### PR TITLE
meta-agent optimization

### DIFF
--- a/mesa/meta_agents/backend.py
+++ b/mesa/meta_agents/backend.py
@@ -131,6 +131,25 @@ class MembershipBackend:
             if linked_group == group_id
         }
 
+    def triplets_for(
+        self, entity_id: Hashable, relation: RelationKey | None = None
+    ) -> set[Triplet]:
+        """Return triplets where *entity_id* is agent or group, using indexes."""
+        result: set[Triplet] = set()
+        # entity as agent (member of groups)
+        for group_id, rel in self._by_agent.get(entity_id, set()):
+            if relation is None or rel == relation:
+                result.add((entity_id, group_id, rel))
+        # entity as group (has members)
+        for group_id, rel in self._by_group.get(entity_id, set()):
+            if relation is None or rel == relation:
+                result.add((group_id, entity_id, rel))
+        return result
+
+    def all_entity_ids(self) -> set[Hashable]:
+        """Return every entity id known to the backend (agents and groups)."""
+        return set(self._by_agent.keys()) | set(self._by_group.keys())
+
     def as_triplets(self) -> set[Triplet]:
         """Return all memberships as canonical triplets."""
         return set(self._triplets)

--- a/mesa/meta_agents/meta_agents_api.py
+++ b/mesa/meta_agents/meta_agents_api.py
@@ -138,7 +138,8 @@ class MetaAgents:
                 return entity
         warnings.warn(
             f"Entity with id {entity_id!r} not found among model agents. "
-            f"Returning the raw id as a fallback.",
+            f"Entity reference not found in model agents."
+            f"Please pass valid Agent objects or IDs.",
             UserWarning,
             stacklevel=2,
         )

--- a/mesa/meta_agents/meta_agents_api.py
+++ b/mesa/meta_agents/meta_agents_api.py
@@ -78,39 +78,80 @@ class MetaAgents:
         self.backend = backend or MembershipBackend()
         model.meta_agents = self
 
+        # Cached mapping from backend entity ids to live model objects.
+        # Populated incrementally by mutation methods; seeded once on first
+        # access via _ensure_cache() for pre-existing backend state.
+        self._id_to_entity: dict[Hashable, Any] = {}
+        self._cache_seeded: bool = False
+
         self.model._register_agent_removed_hook(self._on_agent_removed)
 
     def _on_agent_removed(self, agent) -> None:
         """Deactivate memberships when a live agent leaves the model."""
         self.deactivate(agent)
+        entity_id = self._entity_id(agent)
+        self._id_to_entity.pop(entity_id, None)
 
     def _entity_id(self, entity: Hashable) -> Hashable:
         """Return the backend identity for a live entity or hashable external id."""
         return getattr(entity, "unique_id", entity)
 
-    def _live_entity_lookup(self) -> dict[Hashable, Any]:
-        """Build a lookup from backend ids back to live model objects."""
-        # TODO(perf): This rebuilds an O(N) mapping over every model agent on
-        # each call. Cache the lookup instead and only rebuild it on agent add
-        # or remove calls (e.g. via the model's agent lifecycle hooks, seeding
-        # once in ``__init__``). Future optimization: bulk adds and removes.
-        lookup: dict[Hashable, Any] = {}
+    def _cache_entity(self, entity: Any) -> None:
+        """Store a live entity in the id-to-object cache."""
+        entity_id = getattr(entity, "unique_id", None)
+        if entity_id is not None:
+            self._id_to_entity[entity_id] = entity
+
+    def _ensure_cache(self) -> None:
+        """One-time seed of the cache for any pre-existing backend state.
+
+        Only scans the model agents whose ids are already known to the
+        backend, making this O(N_model) once rather than on every call.
+        After the seed, all future entries come from mutation methods.
+        """
+        if self._cache_seeded:
+            return
+        self._cache_seeded = True
+        needed = self.backend.all_entity_ids() - self._id_to_entity.keys()
+        if not needed:
+            return
         for entity in self.model.agents:
             entity_id = getattr(entity, "unique_id", None)
-            if entity_id is not None:
-                lookup[entity_id] = entity
-        return lookup
+            if entity_id is not None and entity_id in needed:
+                self._id_to_entity[entity_id] = entity
+                needed.discard(entity_id)
+                if not needed:
+                    break
+
+    def _resolve_id(self, entity_id: Hashable) -> Any:
+        """Look up a cached entity, falling back to a model scan on miss.
+
+        On a cache miss the model agents are scanned for the specific id.
+        The result is cached so subsequent lookups are O(1).
+        Returns the raw *entity_id* when no live object is found.
+        """
+        self._ensure_cache()
+        hit = self._id_to_entity.get(entity_id)
+        if hit is not None:
+            return hit
+        # Fallback: scan model agents for this specific id.
+        for entity in self.model.agents:
+            eid = getattr(entity, "unique_id", None)
+            if eid == entity_id:
+                self._id_to_entity[eid] = entity
+                return entity
+        return entity_id
 
     def _resolve_entity(self, entity_id: Hashable) -> Any:
         """Resolve a backend id back to a live object when possible."""
-        return self._live_entity_lookup().get(entity_id, entity_id)
+        return self._resolve_id(entity_id)
 
     def _resolve_group(self, group: Hashable) -> Any:
         """Resolve a group from a live object, unique id, or group name."""
-        lookup = self._live_entity_lookup()
+        self._ensure_cache()
         entity_id = self._entity_id(group)
-        if entity_id in lookup:
-            return lookup[entity_id]
+        if entity_id in self._id_to_entity:
+            return self._id_to_entity[entity_id]
         if isinstance(group, str):
             matches = list(
                 dict.fromkeys(
@@ -131,7 +172,8 @@ class MetaAgents:
         self, entity: Hashable, triplets: Iterable[Triplet]
     ) -> MembershipView:
         """Convert backend triplets into a user-facing snapshot."""
-        lookup = self._live_entity_lookup()
+        self._ensure_cache()
+        cache = self._id_to_entity
         resolved_edges: list[MembershipEdge] = []
         for agent_id, group_id, relation in sorted(
             triplets,
@@ -143,8 +185,8 @@ class MetaAgents:
         ):
             resolved_edges.append(
                 MembershipEdge(
-                    agent=lookup.get(agent_id, agent_id),
-                    group=lookup.get(group_id, group_id),
+                    agent=cache.get(agent_id, agent_id),
+                    group=cache.get(group_id, group_id),
                     relation=relation,
                 )
             )
@@ -265,6 +307,11 @@ class MetaAgents:
             [(member, meta_agent, rel) for member, rel in member_relations]
         )
 
+        # Cache all entities involved so future lookups are O(1).
+        self._cache_entity(meta_agent)
+        for member, _rel in member_relations:
+            self._cache_entity(member)
+
         return meta_agent
 
     def add_member(
@@ -274,11 +321,12 @@ class MetaAgents:
         relation: RelationKey = "member",
     ) -> MembershipView:
         """Add one member to one group."""
-        lookup = self._live_entity_lookup()
-        member = lookup.get(self._entity_id(member), member)
+        member = self._resolve_id(self._entity_id(member))
         group = self._resolve_group(group)
 
         self.backend.add_membership(member, group, relation)
+        self._cache_entity(member)
+        self._cache_entity(group)
         return self.query_memberships(member)
 
     def remove_member(
@@ -288,8 +336,7 @@ class MetaAgents:
         relation: RelationKey = "member",
     ) -> MembershipView:
         """Remove one member from one group."""
-        lookup = self._live_entity_lookup()
-        member = lookup.get(self._entity_id(member), member)
+        member = self._resolve_id(self._entity_id(member))
         group = self._resolve_group(group)
 
         self.backend.remove_membership(member, group, relation)
@@ -300,13 +347,14 @@ class MetaAgents:
     ) -> AgentSet:
         """Return the live members of one group as an AgentSet."""
         group = self._resolve_group(group)
-        lookup = self._live_entity_lookup()
+        self._ensure_cache()
+        cache = self._id_to_entity
         members = [
-            lookup[member_id]
+            cache[member_id]
             for member_id in sorted(
                 self.backend.agents_of(group, relation=relation), key=str
             )
-            if member_id in lookup
+            if member_id in cache
         ]
         return AgentSet(members, random=self.model.random)
 
@@ -314,13 +362,14 @@ class MetaAgents:
         self, agent: Hashable, relation: RelationKey | None = None
     ) -> AgentSet:
         """Return the live groups that contain one agent as an AgentSet."""
-        lookup = self._live_entity_lookup()
+        self._ensure_cache()
+        cache = self._id_to_entity
         groups = [
-            lookup[group_id]
+            cache[group_id]
             for group_id in sorted(
                 self.backend.groups_of(agent, relation=relation), key=str
             )
-            if group_id in lookup
+            if group_id in cache
         ]
         return AgentSet(groups, random=self.model.random)
 
@@ -329,12 +378,7 @@ class MetaAgents:
     ) -> MembershipView:
         """Return a resolved, read-only snapshot of one entity's memberships."""
         entity_id = self._entity_id(entity)
-        triplets = (
-            triplet
-            for triplet in self.backend.as_triplets()
-            if (triplet[0] == entity_id or triplet[1] == entity_id)
-            and (relation is None or triplet[2] == relation)
-        )
+        triplets = self.backend.triplets_for(entity_id, relation)
         return self._resolve_view(entity_id, triplets)
 
     def dissolve(self, entity: Hashable) -> MembershipView:
@@ -392,13 +436,16 @@ class MetaAgents:
         if level < 0:
             raise ValueError(f"level must be non-negative, got {level}")
 
-        lookup = self._live_entity_lookup()
+        self._ensure_cache()
+        cache = self._id_to_entity
         root_id = self._entity_id(root)
-        if root_id not in lookup:
+        # Ensure root is cached even when it has no memberships.
+        root_obj = self._resolve_id(root_id)
+        if root_obj is root_id:
             raise ValueError(f"root {root!r} is not registered in the model")
 
         if level == 0:
-            return AgentSet([lookup[root_id]], random=self.model.random)
+            return AgentSet([cache[root_id]], random=self.model.random)
 
         # BFS downward: group -> members. First visit is nearest depth.
         visited: set[Hashable] = {root_id}
@@ -419,7 +466,7 @@ class MetaAgents:
                 visited.add(member_id)
                 next_depth = depth + 1
                 if next_depth == level:
-                    entity = lookup.get(member_id)
+                    entity = cache.get(member_id)
                     if entity is not None:
                         at_depth.append(entity)
                 elif next_depth < level:

--- a/mesa/meta_agents/meta_agents_api.py
+++ b/mesa/meta_agents/meta_agents_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import itertools
+import warnings
 from collections import deque
 from collections.abc import Callable, Hashable, Iterable
 from dataclasses import dataclass
@@ -135,6 +136,12 @@ class MetaAgents:
             if eid == entity_id:
                 self._id_to_entity[eid] = entity
                 return entity
+        warnings.warn(
+            f"Entity with id {entity_id!r} not found among model agents. "
+            f"Returning the raw id as a fallback.",
+            UserWarning,
+            stacklevel=2,
+        )
         return entity_id
 
     def _resolve_entity(self, entity_id: Hashable) -> Any:

--- a/mesa/meta_agents/meta_agents_api.py
+++ b/mesa/meta_agents/meta_agents_api.py
@@ -136,13 +136,13 @@ class MetaAgents:
             if eid == entity_id:
                 self._id_to_entity[eid] = entity
                 return entity
-        warnings.warn(
-            f"Entity with id {entity_id!r} not found among model agents. "
-            f"Entity reference not found in model agents."
-            f"Please pass valid Agent objects or IDs.",
-            UserWarning,
-            stacklevel=2,
-        )
+        if entity_id in self.backend.all_entity_ids():
+            warnings.warn(
+                f"Entity with id {entity_id!r} not found among model agents. "
+                f"Please pass valid Agent objects or IDs.",
+                UserWarning,
+                stacklevel=2,
+            )
         return entity_id
 
     def _resolve_entity(self, entity_id: Hashable) -> Any:

--- a/mesa/meta_agents/meta_agents_api.py
+++ b/mesa/meta_agents/meta_agents_api.py
@@ -124,12 +124,7 @@ class MetaAgents:
                     break
 
     def _resolve_id(self, entity_id: Hashable) -> Any:
-        """Look up a cached entity, falling back to a model scan on miss.
-
-        On a cache miss the model agents are scanned for the specific id.
-        The result is cached so subsequent lookups are O(1).
-        Returns the raw *entity_id* when no live object is found.
-        """
+        """Look up a cached entity, falling back to a model.agents scan on miss."""
         self._ensure_cache()
         hit = self._id_to_entity.get(entity_id)
         if hit is not None:
@@ -143,11 +138,11 @@ class MetaAgents:
         return entity_id
 
     def _resolve_entity(self, entity_id: Hashable) -> Any:
-        """Resolve a backend id back to a live object when possible."""
+        """Resolve a backend id back to an agent when possible."""
         return self._resolve_id(entity_id)
 
     def _resolve_group(self, group: Hashable) -> Any:
-        """Resolve a group from a live object, unique id, or group name."""
+        """Resolve a group from an agent object, unique id, or group name."""
         self._ensure_cache()
         entity_id = self._entity_id(group)
         if entity_id in self._id_to_entity:

--- a/tests/test_meta_agents_api.py
+++ b/tests/test_meta_agents_api.py
@@ -1,5 +1,7 @@
 """Tests for the meta-agents membership manager."""
 
+import warnings
+
 import pytest
 
 from mesa import Agent, Model
@@ -494,13 +496,11 @@ def test_resolve_id_fallback_scan_populates_cache():
 
 def test_resolve_id_warns_on_missing_entity():
     """_resolve_id emits a UserWarning when the entity id is not found."""
-    import warnings as _warnings
-
     model = Model()
     meta_agents = MetaAgents(model)
 
-    with _warnings.catch_warnings(record=True) as caught:
-        _warnings.simplefilter("always")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
         result = meta_agents._resolve_id("nonexistent_id")
 
     assert result == "nonexistent_id"
@@ -512,14 +512,12 @@ def test_resolve_id_warns_on_missing_entity():
 
 def test_resolve_id_no_warning_when_entity_found():
     """_resolve_id does NOT warn when the entity exists in the model."""
-    import warnings as _warnings
-
     model = Model()
     meta_agents = MetaAgents(model)
     agent = Agent(model)
 
-    with _warnings.catch_warnings(record=True) as caught:
-        _warnings.simplefilter("always")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
         result = meta_agents._resolve_id(agent.unique_id)
 
     assert result is agent

--- a/tests/test_meta_agents_api.py
+++ b/tests/test_meta_agents_api.py
@@ -379,3 +379,149 @@ def test_at_level_cyclic_membership_terminates():
     assert set(meta_agents.at_level(0, root=a)) == {a}
     assert set(meta_agents.at_level(1, root=a)) == {b}
     assert set(meta_agents.at_level(2, root=a)) == set()
+
+
+# ── _cache_entity tests ────────────────────────────────────────────────
+
+
+def test_cache_entity_stores_agent_by_unique_id():
+    """_cache_entity stores a live agent under its unique_id."""
+    model = Model()
+    meta_agents = MetaAgents(model)
+    agent = Agent(model)
+
+    meta_agents._cache_entity(agent)
+
+    assert meta_agents._id_to_entity[agent.unique_id] is agent
+
+
+def test_cache_entity_skips_entity_without_unique_id():
+    """_cache_entity silently ignores entities with no unique_id attribute."""
+    model = Model()
+    meta_agents = MetaAgents(model)
+
+    plain = object()  # no unique_id attribute
+    meta_agents._cache_entity(plain)
+
+    assert plain not in meta_agents._id_to_entity.values()
+
+
+def test_cache_entity_overwrites_stale_entry():
+    """A second _cache_entity call with the same unique_id replaces the old reference."""
+    model = Model()
+    meta_agents = MetaAgents(model)
+    agent = Agent(model)
+    uid = agent.unique_id
+
+    meta_agents._cache_entity(agent)
+    assert meta_agents._id_to_entity[uid] is agent
+
+    # Simulate a replacement agent with the same unique_id
+    class FakeAgent:
+        unique_id = uid
+
+    replacement = FakeAgent()
+    meta_agents._cache_entity(replacement)
+    assert meta_agents._id_to_entity[uid] is replacement
+
+
+# ── _ensure_cache tests ────────────────────────────────────────────────
+
+
+def test_ensure_cache_seeds_from_backend():
+    """_ensure_cache populates the cache from backend entity ids on first call."""
+    model = Model()
+    meta_agents = MetaAgents(model)
+    a = Agent(model)
+    b = Agent(model)
+    group = meta_agents.create("Group", [a, b])
+
+    # Clear the cache to simulate cold start with pre-existing backend state.
+    meta_agents._id_to_entity.clear()
+    meta_agents._cache_seeded = False
+
+    meta_agents._ensure_cache()
+
+    assert meta_agents._cache_seeded is True
+    assert meta_agents._id_to_entity[a.unique_id] is a
+    assert meta_agents._id_to_entity[b.unique_id] is b
+    assert meta_agents._id_to_entity[group.unique_id] is group
+
+
+def test_ensure_cache_runs_only_once():
+    """_ensure_cache skips re-scanning after the first seed."""
+    model = Model()
+    meta_agents = MetaAgents(model)
+    Agent(model)
+
+    meta_agents._ensure_cache()
+    assert meta_agents._cache_seeded is True
+
+    # Manually inject a sentinel to prove the scan doesn't re-run.
+    meta_agents._id_to_entity["sentinel"] = "marker"
+    meta_agents._ensure_cache()
+    assert meta_agents._id_to_entity["sentinel"] == "marker"
+
+
+# ── _resolve_id cache integration tests ────────────────────────────────
+
+
+def test_resolve_id_uses_cache():
+    """_resolve_id returns a cached entity without scanning model.agents."""
+    model = Model()
+    meta_agents = MetaAgents(model)
+    agent = Agent(model)
+    meta_agents._cache_entity(agent)
+
+    result = meta_agents._resolve_id(agent.unique_id)
+    assert result is agent
+
+
+def test_resolve_id_fallback_scan_populates_cache():
+    """_resolve_id scans model.agents on cache miss and stores the result."""
+    model = Model()
+    meta_agents = MetaAgents(model)
+    agent = Agent(model)
+
+    # Ensure cache is seeded but doesn't contain the agent.
+    meta_agents._cache_seeded = True
+    assert agent.unique_id not in meta_agents._id_to_entity
+
+    result = meta_agents._resolve_id(agent.unique_id)
+    assert result is agent
+    assert meta_agents._id_to_entity[agent.unique_id] is agent
+
+
+def test_resolve_id_warns_on_missing_entity():
+    """_resolve_id emits a UserWarning when the entity id is not found."""
+    import warnings as _warnings
+
+    model = Model()
+    meta_agents = MetaAgents(model)
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        result = meta_agents._resolve_id("nonexistent_id")
+
+    assert result == "nonexistent_id"
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, UserWarning)
+    assert "nonexistent_id" in str(caught[0].message)
+    assert "not found" in str(caught[0].message)
+
+
+def test_resolve_id_no_warning_when_entity_found():
+    """_resolve_id does NOT warn when the entity exists in the model."""
+    import warnings as _warnings
+
+    model = Model()
+    meta_agents = MetaAgents(model)
+    agent = Agent(model)
+
+    with _warnings.catch_warnings(record=True) as caught:
+        _warnings.simplefilter("always")
+        result = meta_agents._resolve_id(agent.unique_id)
+
+    assert result is agent
+    assert len(caught) == 0
+

--- a/tests/test_meta_agents_api.py
+++ b/tests/test_meta_agents_api.py
@@ -524,4 +524,3 @@ def test_resolve_id_no_warning_when_entity_found():
 
     assert result is agent
     assert len(caught) == 0
-

--- a/tests/test_meta_agents_api.py
+++ b/tests/test_meta_agents_api.py
@@ -540,4 +540,3 @@ def test_resolve_id_no_warning_when_entity_found():
 
     assert result is agent
     assert len(caught) == 0
-

--- a/tests/test_meta_agents_api.py
+++ b/tests/test_meta_agents_api.py
@@ -494,20 +494,38 @@ def test_resolve_id_fallback_scan_populates_cache():
     assert meta_agents._id_to_entity[agent.unique_id] is agent
 
 
-def test_resolve_id_warns_on_missing_entity():
-    """_resolve_id emits a UserWarning when the entity id is not found."""
+def test_resolve_id_warns_on_stale_backend_reference():
+    """_resolve_id emits a UserWarning for an id known to the backend but not in the model."""
+    model = Model()
+    meta_agents = MetaAgents(model)
+    agent = Agent(model)
+    group = meta_agents.create("Group", [agent])
+
+    # Inject a backend edge referencing an id with no live model agent.
+    meta_agents.backend.add_membership("ghost_id", group.unique_id, "member")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = meta_agents._resolve_id("ghost_id")
+
+    assert result == "ghost_id"
+    assert len(caught) == 1
+    assert issubclass(caught[0].category, UserWarning)
+    assert "ghost_id" in str(caught[0].message)
+    assert "not found" in str(caught[0].message)
+
+
+def test_resolve_id_no_warning_for_unknown_id():
+    """_resolve_id does NOT warn for an id unknown to the backend."""
     model = Model()
     meta_agents = MetaAgents(model)
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        result = meta_agents._resolve_id("nonexistent_id")
+        result = meta_agents._resolve_id("totally_unknown")
 
-    assert result == "nonexistent_id"
-    assert len(caught) == 1
-    assert issubclass(caught[0].category, UserWarning)
-    assert "nonexistent_id" in str(caught[0].message)
-    assert "not found" in str(caught[0].message)
+    assert result == "totally_unknown"
+    assert len(caught) == 0
 
 
 def test_resolve_id_no_warning_when_entity_found():
@@ -522,3 +540,4 @@ def test_resolve_id_no_warning_when_entity_found():
 
     assert result is agent
     assert len(caught) == 0
+

--- a/tests/test_meta_agents_backend.py
+++ b/tests/test_meta_agents_backend.py
@@ -108,3 +108,92 @@ def test_backend_uses_unique_ids_for_mesa_agents():
     assert meta_agents.backend.groups_of(agent) == {group.unique_id}
     assert meta_agents.backend.agents_of(group) == {agent.unique_id}
     meta_agents.backend.assert_invariants()
+
+
+def test_triplets_for_entity_as_agent():
+    """triplets_for returns edges where the entity is the agent (member)."""
+    backend = MembershipBackend()
+    backend.add_membership("a1", "g1", "member")
+    backend.add_membership("a1", "g2", "leader")
+    backend.add_membership("a2", "g1", "member")
+
+    result = backend.triplets_for("a1")
+    assert result == {("a1", "g1", "member"), ("a1", "g2", "leader")}
+
+
+def test_triplets_for_entity_as_group():
+    """triplets_for returns edges where the entity is the group."""
+    backend = MembershipBackend()
+    backend.add_membership("a1", "g1", "member")
+    backend.add_membership("a2", "g1", "leader")
+
+    result = backend.triplets_for("g1")
+    assert result == {("a1", "g1", "member"), ("a2", "g1", "leader")}
+
+
+def test_triplets_for_entity_as_both_agent_and_group():
+    """triplets_for returns edges from both sides when entity is agent AND group."""
+    backend = MembershipBackend()
+    backend.add_membership("a1", "mid", "member")
+    backend.add_membership("mid", "g1", "member")
+
+    result = backend.triplets_for("mid")
+    # mid is an agent of g1 and a group containing a1
+    assert result == {("mid", "g1", "member"), ("a1", "mid", "member")}
+
+
+def test_triplets_for_with_relation_filter():
+    """triplets_for filters by relation when specified."""
+    backend = MembershipBackend()
+    backend.add_membership("a1", "g1", "member")
+    backend.add_membership("a1", "g1", "leader")
+    backend.add_membership("a2", "g1", "member")
+
+    result = backend.triplets_for("a1", relation="leader")
+    assert result == {("a1", "g1", "leader")}
+
+    result_group = backend.triplets_for("g1", relation="member")
+    assert result_group == {("a1", "g1", "member"), ("a2", "g1", "member")}
+
+
+def test_triplets_for_unknown_entity():
+    """triplets_for returns an empty set for an entity with no edges."""
+    backend = MembershipBackend()
+    backend.add_membership("a1", "g1", "member")
+
+    assert backend.triplets_for("unknown") == set()
+
+
+def test_all_entity_ids_populated():
+    """all_entity_ids returns every agent and group id in the backend."""
+    backend = MembershipBackend()
+    backend.add_membership("a1", "g1", "member")
+    backend.add_membership("a2", "g2", "leader")
+
+    assert backend.all_entity_ids() == {"a1", "a2", "g1", "g2"}
+
+
+def test_all_entity_ids_empty():
+    """all_entity_ids returns an empty set when backend has no edges."""
+    backend = MembershipBackend()
+    assert backend.all_entity_ids() == set()
+
+
+def test_all_entity_ids_after_removal():
+    """all_entity_ids shrinks when agents/groups are removed."""
+    backend = MembershipBackend()
+    backend.add_membership("a1", "g1", "member")
+    backend.add_membership("a2", "g1", "leader")
+
+    backend.remove_agent("a1")
+    ids = backend.all_entity_ids()
+    assert "a1" not in ids
+    assert "a2" in ids
+    assert "g1" in ids
+
+    backend.remove_group("g1")
+    ids = backend.all_entity_ids()
+    assert "g1" not in ids
+    # a2 was only linked to g1, so after removing g1 its entry is also gone
+    assert "a2" not in ids
+

--- a/tests/test_meta_agents_backend.py
+++ b/tests/test_meta_agents_backend.py
@@ -196,4 +196,3 @@ def test_all_entity_ids_after_removal():
     assert "g1" not in ids
     # a2 was only linked to g1, so after removing g1 its entry is also gone
     assert "a2" not in ids
-


### PR DESCRIPTION
### Summary
The meta-agent api module currently looks through all agents multiple times via `_live_entity_lookup` this creates a significant bottleneck. This PR focuses on using the membership store as the reference that the meta-agent-apis uses, creating significant speed up. Related to #3828 

### Implementation
Add `triplets_for` and `all_entity_id` to `backend` to provide more membership store reference options
Update to `meta-agents-api` to use a mixture of caching, membership store look ups and fallback lookup to `model` if needed