### PR TITLE
enchanced the performance of random empty cell

### DIFF
--- a/mesa/discrete_space/grid.py
+++ b/mesa/discrete_space/grid.py
@@ -113,6 +113,10 @@ class Grid(DiscreteSpace[T]):
         # Track which property layers are read-only so the constraint survives
         # pickling and deepcopy (see __getstate__/__setstate__).
         self._read_only_layers: set[str] = set()
+        self._empty_cell_count = math.prod(self.dimensions)
+        self._empty_cells: list[T] = []
+        self._empty_cell_indices: dict[tuple[int, ...], int] = {}
+        self._maintain_empty_cells = False
 
         # we register the pickle_gridcell helper function
         copyreg.pickle(self.cell_klass, pickle_gridcell)
@@ -207,6 +211,13 @@ class Grid(DiscreteSpace[T]):
             return array[self_cell.coordinate]
 
         def setter(self_cell, value):
+            if name == "empty":
+                old_value = bool(array[self_cell.coordinate])
+                new_value = bool(value)
+                if old_value != new_value:
+                    self._empty_cell_count += 1 if new_value else -1
+                    if self._maintain_empty_cells:
+                        self._update_empty_cell_index(self_cell, new_value)
             array[self_cell.coordinate] = value
 
         accessor = (
@@ -218,6 +229,27 @@ class Grid(DiscreteSpace[T]):
         self.cell_klass.property_layers.add(name)
         if read_only:
             self._read_only_layers.add(name)
+
+    def _update_empty_cell_index(self, cell: T, is_empty: bool) -> None:
+        """Keep the random-access empty-cell collection synchronized."""
+        coordinate = cell.coordinate
+        if is_empty:
+            self._empty_cell_indices[coordinate] = len(self._empty_cells)
+            self._empty_cells.append(cell)
+            return
+
+        index = self._empty_cell_indices.pop(coordinate)
+        last_cell = self._empty_cells.pop()
+        if last_cell is not cell:
+            self._empty_cells[index] = last_cell
+            self._empty_cell_indices[last_cell.coordinate] = index
+
+    def _start_empty_cell_maintenance(self) -> None:
+        self._empty_cells = [cell for cell in self._celllist if cell.is_empty]
+        self._empty_cell_indices = {
+            cell.coordinate: index for index, cell in enumerate(self._empty_cells)
+        }
+        self._maintain_empty_cells = True
 
     def get_neighborhood_mask(
         self, coordinate, include_center: bool = True, radius: int = 1
@@ -286,34 +318,37 @@ class Grid(DiscreteSpace[T]):
             raise TypeError("Capacity must be a number or None.")
 
     def select_random_empty_cell(self) -> T:  # noqa
-        # Use a heuristic: try random sampling first for performance (O(1))
-        # FIXME:: basically if grid is close to 99% full, creating empty list can be faster
-        # FIXME:: note however that the old results don't apply because in this implementation
-        # FIXME:: because empties list needs to be rebuild each time
-        # This method is based on Agents.jl's random_empty() implementation. See
-        # https://github.com/JuliaDynamics/Agents.jl/pull/541. For the discussion, see
-        # https://github.com/mesa/mesa/issues/1052 and
-        # https://github.com/mesa/mesa/pull/1565. The cutoff value provided
-        # is the break-even comparison with the time taken in the else branching point.
         random = self.random
         cells = self._celllist
 
+        if (
+            not self._maintain_empty_cells
+            and self._empty_cell_count <= len(cells) * 0.1
+        ):
+            self._start_empty_cell_maintenance()
+
+        if self._maintain_empty_cells:
+            if not self._empty_cells:
+                raise ValueError(
+                    "Grid is completely full. No empty cells available. "
+                    "Cannot select a random empty cell."
+                )
+            return random.choice(self._empty_cells)
+
         if self._try_random:
-            # Limit attempts to avoid infinite loops on full grids
             for _ in range(50):
                 cell = random.choice(cells)
                 if cell.is_empty:
                     return cell
 
-        empty_coords = np.argwhere(self.property_layers["empty"])
-        try:
-            random_coord = self.random.choice(empty_coords)
-        except IndexError as e:
+        if self._empty_cell_count == 0:
             raise ValueError(
                 "Grid is completely full. No empty cells available. "
                 "Cannot select a random empty cell."
-            ) from e
-        return self._cells[tuple(random_coord)]
+            )
+
+        self._start_empty_cell_maintenance()
+        return random.choice(self._empty_cells)
 
     @property
     def cells_with_capacity(self) -> CellCollection[T]:

--- a/tests/discrete_space/test_discrete_space.py
+++ b/tests/discrete_space/test_discrete_space.py
@@ -1235,6 +1235,32 @@ def test_select_random_empty_cell_fallback():
     assert not grid.property_layers["empty"][0, 0]
 
 
+def test_select_random_empty_cell_maintains_empty_cells():
+    """Test that dense grids maintain an up-to-date empty-cell collection."""
+    model = Model()
+    grid = OrthogonalMooreGrid((10, 10), random=model.random)
+    target_empty = {(x, 0) for x in range(10)}
+
+    for coordinate, cell in grid._cells.items():
+        if coordinate not in target_empty:
+            cell.add_agent(CellAgent(model))
+
+    selected_cell = grid.select_random_empty_cell()
+
+    assert grid._maintain_empty_cells
+    assert len(grid._empty_cells) == 10
+    assert selected_cell.coordinate in target_empty
+
+    agent = CellAgent(model)
+    selected_cell.add_agent(agent)
+    assert len(grid._empty_cells) == 9
+    assert selected_cell.coordinate not in grid._empty_cell_indices
+
+    selected_cell.remove_agent(agent)
+    assert len(grid._empty_cells) == 10
+    assert selected_cell.coordinate in grid._empty_cell_indices
+
+
 def test_fixed_agent_removal_state():
     """Test that a FixedAgent's cell is None after removal."""
     model = Model()


### PR DESCRIPTION
### Pre-PR Checklist
- [X] I linked an issue/discussion where a maintainer approved this enhancement/feature for implementation.

### Approval Link
#3836 

### Summary
Draft proposal for optimizing `Grid.select_random_empty_cell()` on dense grids, without adding always-on maintenance overhead addressing the concern  that a persistently maintained empty-cells structure would be wasteful on sparse grids.
### Motive
Currently, `select_random_empty_cell()` tries up to 50 random guesses, then falls back to `np.argwhere(self.property_layers["empty"])` a full O(n) scan of the grid every single call once guessing fails. On a nearly-full grid, this means repeated full scans on every call, which gets expensive as the grid approaches capacity. 
### Implementation
A lightweight `_empty_cell_count` integer is updated via the existing `property_layers["empty"]`  setter whenever a cell's emptiness changes O(1) per change, effectively free.
Once `_empty_cell_count` drops below a threshold (currently a placeholder not yet benchmarked, see Additional Notes), `_start_empty_cell_maintenance()` builds a `_empty_cells`  list + `_empty_cell_indices`  dict, enabling O(1) add/remove/random-pick from then on via swap-and-pop.
Below that threshold, no maintenance happens at all zero added overhead on the common case of a sparse grid, directly addressing the concern about wasted cost on largely-empty grids.



### Additional Notes
Opening as a draft, not merge-ready. The current `10%` threshold is a placeholder and hasn’t been empirically validated yet. I’m benchmarking across densities and grid sizes to find the actual break-even point. Opening early to get feedback on the approach before finalizing the value. @quaquel  flagging you since this addresses the original concern you raised.
