### PR TITLE
Fix StopIteration when reusing a meta-agent group name after dissolve

### DIFF
--- a/mesa/meta_agents/meta_agent.py
+++ b/mesa/meta_agents/meta_agent.py
@@ -41,10 +41,7 @@ def extract_class(agents_by_type: dict, new_agent_class: object) -> type[Agent] 
     agent_type_names = {
         agent_type.__name__: agent_type for agent_type in agents_by_type
     }
-    agent_type = agent_type_names.get(new_agent_class)
-    if agent_type is None:
-        return None
-    return type(next(iter(agents_by_type[agent_type])))
+    return agent_type_names.get(new_agent_class)
 
 
 def _apply_meta_attributes(

--- a/tests/test_meta_agents_backend.py
+++ b/tests/test_meta_agents_backend.py
@@ -3,6 +3,7 @@
 from mesa import Agent, Model
 from mesa.meta_agents import MetaAgents
 from mesa.meta_agents.backend import MembershipBackend
+from mesa.meta_agents.meta_agent import extract_class
 
 
 def test_add_and_query():
@@ -108,3 +109,48 @@ def test_backend_uses_unique_ids_for_mesa_agents():
     assert meta_agents.backend.groups_of(agent) == {group.unique_id}
     assert meta_agents.backend.agents_of(group) == {agent.unique_id}
     meta_agents.backend.assert_invariants()
+
+
+def test_group_name_can_be_reused_after_dissolve():
+    """Recreating a dissolved group name should not raise.
+
+    ``agents_by_type`` keeps the bucket for a class after its last instance is
+    removed, so a name lookup still succeeds while the bucket is empty.
+    """
+    model = Model()
+    meta_agents = MetaAgents(model)
+    first, second = Agent(model), Agent(model)
+
+    group = meta_agents.create("Team", [first, second])
+    meta_agents.dissolve(group)
+
+    regrouped = meta_agents.create("Team", [first, second])
+
+    assert set(meta_agents.members_of(regrouped)) == {first, second}
+    meta_agents.backend.assert_invariants()
+
+
+def test_reused_group_name_keeps_the_same_class():
+    """The dissolved group's class is reused, so isinstance stays reliable."""
+    model = Model()
+    meta_agents = MetaAgents(model)
+    agent = Agent(model)
+
+    group = meta_agents.create("Team", [agent])
+    original_class = type(group)
+    meta_agents.dissolve(group)
+
+    regrouped = meta_agents.create("Team", [agent])
+
+    assert type(regrouped) is original_class
+    assert isinstance(regrouped, original_class)
+
+
+def test_extract_class_returns_the_registered_class():
+    """extract_class resolves a live class, and None for an unknown name."""
+    model = Model()
+    meta_agents = MetaAgents(model)
+    group = meta_agents.create("Team", [Agent(model)])
+
+    assert extract_class(model.agents_by_type, "Team") is type(group)
+    assert extract_class(model.agents_by_type, "NoSuchGroup") is None


### PR DESCRIPTION
Ref #3849.

### Problem

Create a meta-agent group, dissolve it, create another with the same name → `StopIteration`.

`extract_class` looks the class up by name, then reads the type back off a live instance. Dissolving the last group of a name empties that `agents_by_type` bucket but keeps the key, so the name lookup still succeeds, the `None` early-return doesn't fire, and `next(iter(...))` runs on an empty set.

### Change
```diff
     agent_type_names = {
         agent_type.__name__: agent_type for agent_type in agents_by_type
     }
-    agent_type = agent_type_names.get(new_agent_class)
-    if agent_type is None:
-        return None
-    return type(next(iter(agents_by_type[agent_type])))
+    return agent_type_names.get(new_agent_class)
```

Model.register_agent keys the dict by exact type, so the existing name lookup already yields the class and the instance round-trip was redundant. Returning it directly gives the same object for every populated bucket — including the duplicate-name case, where the comprehension's last-wins behaviour is unchanged and no longer needs a live instance to exist.

Alternatives

Happy to go another way 

Opening as a draft since #3849 is still open for discussion glad to reshape this whichever way you prefer.

Tests

Three added to tests/test_meta_agents_backend.py: reuse after dissolve doesn't raise; the original class is reused rather than re-created; and extract_class resolves a known name and returns None for an unknown one. The first two fail with StopIteration on main; the third passes either way, to show the happy path is unchanged.

Full suite: 791 passed. Four don't pass in my environment (missing pyarrow and some optional viz deps) — identical results with and without this change.