### PR TITLE
Move the action cluster from Agent to a HasActions mixin

### DIFF
--- a/mesa/agent.py
+++ b/mesa/agent.py
@@ -15,15 +15,9 @@ import numpy as np
 import pandas as pd
 
 if TYPE_CHECKING:
-    from mesa.experimental.actions import Action
     from mesa.model import Model
-    from mesa.time import Event
 
 from mesa.agentset import AgentSet, _resolve_per_agent_values
-from mesa.mesa_logging import create_module_logger
-from mesa.time import Priority
-
-_mesa_logger = create_module_logger()
 
 
 class Agent[M: Model]:
@@ -69,49 +63,13 @@ class Agent[M: Model]:
 
         self.model: M = model
         self.unique_id = None
-        self.current_action: Action | None = None
-        self._wake_event: Event | None = None
-        self._wake_previous: Action | None = None
-        self._last_wake_time: float = float("-inf")
         self.model.register_agent(self)
 
         for dataset in self._datasets:
             self.model.data_registry[dataset].add_agent(self)
 
     def remove(self) -> None:
-        """Remove and delete the agent from the model.
-
-        If the agent is currently performing an action, the action's
-        scheduled completion event is cancelled silently. The action's
-        on_interrupt() callback is NOT fired, because the agent is being
-        destroyed — not making a behavioral decision. The action moves
-        to no defined end state; it is simply abandoned. A pending
-        on_idle wake is cancelled as well: a removed agent never wakes.
-
-        If your action holds external resources (e.g., a Resource slot,
-        a reservation, a lock), override Agent.remove() and call
-        self.cancel_action() before super().remove() to ensure
-        on_interrupt() fires and cleanup logic runs:
-
-            def remove(self):
-                self.cancel_action()  # Fires on_interrupt for cleanup
-                super().remove()
-
-        Notes:
-            This is a deliberate design choice. The default silent
-            cleanup is safe and avoids callbacks touching agent state
-            during teardown. Models that need cleanup should opt in
-            explicitly.
-        """
-        if self.current_action is not None:
-            self.current_action._cancel_event()  # Silent cleanup, no callback
-            self.current_action = None
-
-        if self._wake_event is not None:
-            self._wake_event.cancel()
-            self._wake_event = None
-            self._wake_previous = None
-
+        """Remove and delete the agent from the model."""
         with contextlib.suppress(KeyError):
             self.model.deregister_agent(self)
 
@@ -262,178 +220,3 @@ class Agent[M: Model]:
     def scenario(self):
         """Return the scenario associated with the model."""
         return self.model.scenario
-
-    # Actions methods
-    def start_action(self, action: Action) -> Action:
-        """Start performing an action.
-
-        The action must be in PENDING or INTERRUPTED state and the agent
-        must not be currently performing another action.
-
-        If one of the action's start requirements does not hold, the action moves
-        to FAILED instead of starting and the agent stays idle. Check
-        action.has_failed rather than assuming the action is running.
-
-        Args:
-            action: The Action to perform. Must have been created with
-                this agent as its agent.
-
-        Returns:
-            The started Action.
-
-        Raises:
-            ValueError: If the agent is already performing an action,
-                or if the action doesn't belong to this agent.
-        """
-        if self.current_action is not None:
-            raise ValueError(
-                f"Agent {self.unique_id} is already performing an action "
-                f"({self.current_action!r}). Use interrupt_for() or "
-                f"cancel_action() first."
-            )
-
-        if action.agent is not self:
-            raise ValueError(
-                f"Action's agent (id={action.agent.unique_id}) does not match "
-                f"this agent (id={self.unique_id})."
-            )
-
-        self.current_action = action
-        action.start()
-
-        # If the action completed instantly (duration=0), start() already
-        # called _do_complete which cleared current_action via the Action.
-        return action
-
-    def should_interrupt(self, current: Action, incoming: Action) -> bool:
-        """Decide whether an incoming action may preempt the current one.
-
-        Consulted by interrupt_for() whenever the agent is busy, with both
-        priorities already resolved. Override to encode preemption policy,
-        e.g. comparing action names or agent state instead of priorities.
-
-        Args:
-            current: The action the agent is performing.
-            incoming: The action that wants to replace it.
-
-        Returns:
-            True to attempt the interruption, False to refuse it.
-
-        Notes:
-            Returning True cannot override the interruptible flag; use
-            cancel_action() to force. This hook decides policy, the flag
-            stays a hard property of the action.
-        """
-        return current.interruptible and incoming.priority >= current.priority
-
-    def interrupt_for(self, new_action: Action) -> bool:
-        """Interrupt the current action and start a new one.
-
-        If there is no current action, simply starts the new one. Otherwise
-        should_interrupt(current, incoming) decides whether to preempt.
-
-        Args:
-            new_action: The Action to perform instead.
-
-        Returns:
-            True if the new action was started. False if should_interrupt
-            refused, the current action is non-interruptible, or the new
-            action failed its start requirements.
-
-        Notes:
-            The False cases differ in what they leave behind. A refusal
-            changes nothing. A failed requirement does not roll the
-            interruption back: the old action is already INTERRUPTED and
-            the agent is left idle, since whether to resume it is the
-            model's decision.
-        """
-        if self.current_action is not None:
-            new_action._resolve_priority()
-            if not self.should_interrupt(self.current_action, new_action):
-                return False
-            if not self.current_action.interrupt():
-                return False
-                # interrupt() already cleared current_action
-
-        self.start_action(new_action)
-        return not new_action.has_failed
-
-    def cancel_action(self) -> bool:
-        """Cancel the current action, ignoring interruptible flag.
-
-        Calls on_interrupt with partial progress. Returns False only if
-        there is no current action.
-
-        Returns:
-            True if an action was cancelled, False if idle.
-        """
-        if self.current_action is None:
-            return False
-
-        self.current_action.cancel()
-        # cancel() already cleared current_action
-        return True
-
-    @property
-    def is_busy(self) -> bool:
-        """Whether the agent is currently performing an action."""
-        return self.current_action is not None
-
-    def on_idle(self, previous: Action | None) -> None:
-        """Called when the agent's action has ended and nothing replaced it.
-
-        Override it to choose what to do next, typically by starting or
-        resuming an action. The default does nothing, and nothing is
-        resumed automatically: an interrupted action stays interrupted
-        unless this hook (or other model code) restarts it.
-
-        Args:
-            previous: The action that just ended, in its final state
-                (COMPLETED, INTERRUPTED, or FAILED). None is reserved for
-                wakes not caused by an action ending; no built-in trigger
-                sends it today.
-
-        Notes:
-            At most one wake fires per agent per model time, so a
-            zero-duration action started here cannot re-trigger the hook
-            in the same instant; a wake dropped by this guard is logged
-            at DEBUG level. The wake is skipped when the agent is
-            busy again by the time the event runs -- interrupt_for()
-            refills the slot synchronously, so no idle gap ever existed.
-            If several actions end before the wake runs, they coalesce
-            into one call and ``previous`` is the latest of them.
-        """
-
-    def _schedule_wake(self, previous: Action | None) -> None:
-        """Queue the deferred on_idle event, coalescing repeats.
-
-        Called by Action._release_agent whenever this agent's slot is
-        cleared. If a wake is already pending, or one already fired at
-        the current model time, no second event is queued -- only
-        ``previous`` is brought up to date. A wake dropped by the
-        once-per-time guard is logged at DEBUG level.
-        """
-        self._wake_previous = previous
-        if self._wake_event is not None:
-            return
-        if self._last_wake_time == self.model.time:
-            _mesa_logger.debug(
-                f"suppressed repeat on_idle wake for agent {self.unique_id} "
-                f"at time {self.model.time} (ending action: {previous!r})"
-            )
-            return
-        self._wake_event = self.model.schedule_event(
-            self._fire_wake, after=0.0, priority=Priority.LOW
-        )
-
-    def _fire_wake(self) -> None:
-        """Run the pending wake: call on_idle if the agent is still free."""
-        previous = self._wake_previous
-        self._wake_event = None
-        self._wake_previous = None
-        if self.current_action is not None:
-            return
-        # Recorded only when on_idle actually runs, so a busy skip does not
-        # suppress a later release at the same model time.
-        self._last_wake_time = self.model.time
-        self.on_idle(previous)

--- a/mesa/experimental/actions/__init__.py
+++ b/mesa/experimental/actions/__init__.py
@@ -1,8 +1,9 @@
-"""Scenarios module."""
+"""Timed, interruptible actions and the agent mixin that performs them."""
 
-from .actions import Action, ActionState
+from .actions import Action, ActionState, HasActions
 
 __all__ = [
     "Action",
     "ActionState",
+    "HasActions",
 ]

--- a/mesa/experimental/actions/actions.py
+++ b/mesa/experimental/actions/actions.py
@@ -5,11 +5,15 @@ Mesa's event scheduling system for precise timing and supports interruption
 with progress tracking and optional resumption.
 
 Actions are subclassable: override on_start(), on_complete(),
-on_interrupt(), and on_fail() to define behavior. When an action ends,
-the agent's Agent.on_idle() hook fires; decisions about what to do
-next -- chain another action, resume an interrupted one -- belong there.
+on_interrupt(), and on_fail() to define behavior. The agent-side API
+lives on the HasActions mixin; when an action ends, the agent's
+on_idle() hook fires, and decisions about what to do next -- chain
+another action, resume an interrupted one -- belong there.
 
 Example::
+
+    class Sheep(HasActions, Agent):
+        pass
 
     class Forage(Action):
         def __init__(self, sheep):
@@ -30,9 +34,15 @@ from collections.abc import Callable, Iterable
 from enum import IntEnum, auto
 from typing import TYPE_CHECKING
 
+from mesa.mesa_logging import create_module_logger
+from mesa.time import Priority
+
 if TYPE_CHECKING:
     from mesa.agent import Agent
+    from mesa.model import Model
     from mesa.time import Event
+
+_mesa_logger = create_module_logger()
 
 
 class ActionState(IntEnum):
@@ -74,7 +84,7 @@ class Action:
             for state-dependent duration, resolved at start time.
         priority: Importance level. Higher = more important. May be a
             callable(agent) -> float, resolved once: at start, or earlier
-            if Agent.interrupt_for weighs it against a running action.
+            if HasActions.interrupt_for weighs it against a running action.
         interruptible: Whether higher-priority actions can preempt this.
         start_requirements: Predicates that must hold for the action to start.
         completion_requirements: Predicates that must hold for the effect to
@@ -116,13 +126,22 @@ class Action:
             priority: Importance level for interruption decisions. Either
                 a float or a callable that receives the agent and returns
                 a float. Resolved once, at start() or when interrupt_for
-                first consults Agent.should_interrupt with it.
+                first consults the agent's should_interrupt with it.
             interruptible: If False, interrupt() will fail and return False.
             start_requirements: A single callable(agent) -> bool, or an
                 iterable of them. All must hold for the action to start.
             completion_requirements: The same, checked instead when the action
                 completes, gating the effect rather than the attempt.
+
+        Raises:
+            TypeError: If the agent does not inherit from HasActions.
         """
+        if not isinstance(agent, HasActions):
+            raise TypeError(
+                f"Action requires an agent with action support; make "
+                f"{type(agent).__name__} inherit from "
+                f"mesa.experimental.actions.HasActions."
+            )
         self.agent = agent
         self.model = agent.model
         self.interruptible = interruptible
@@ -399,7 +418,7 @@ class Action:
         Completion, interruption, cancellation, and failure all funnel
         through here, so the wake contract has a single path. An action
         that never held the slot (started directly, without
-        Agent.start_action) wakes nobody. Agent.remove() is the one end
+        start_action()) wakes nobody. HasActions.remove() is the one end
         that does not come through here: it abandons the action, and a
         dying agent must not wake.
         """
@@ -410,7 +429,7 @@ class Action:
     def _resolve_priority(self) -> None:
         """Resolve the priority spec against the agent, at most once.
 
-        Called from start(), and from Agent.interrupt_for before it consults
+        Called from start(), and from HasActions.interrupt_for before it consults
         should_interrupt, since the incoming action has not started yet and
         its priority would otherwise still read 0.0. A callable spec is
         called at most once either way.
@@ -459,3 +478,244 @@ class Action:
             f"progress={self.progress:.0%}, "
             f"duration={self.duration})"
         )
+
+
+class HasActions:
+    """Mixin that lets an agent perform Actions.
+
+    An agent performs at most one action at a time, held in
+    ``current_action``. Actions are started with start_action(),
+    preempted through interrupt_for() under the should_interrupt()
+    policy, and force-stopped with cancel_action(). Whenever an action
+    ends and nothing replaces it, the on_idle() wake fires.
+
+    Action instances require their agent to inherit from this mixin.
+    """
+
+    if TYPE_CHECKING:
+        # Supplied by the Agent class this mixin is combined with.
+        model: Model
+        unique_id: int
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize the action slot."""
+        self.current_action: Action | None = None
+        self._wake_event: Event | None = None
+        self._wake_previous: Action | None = None
+        self._last_wake_time: float = float("-inf")
+        super().__init__(*args, **kwargs)
+
+    def remove(self) -> None:
+        """Remove the agent, abandoning its action and pending wake.
+
+        If the agent is currently performing an action, the action's
+        scheduled completion event is cancelled silently. The action's
+        on_interrupt() callback is NOT fired, because the agent is being
+        destroyed — not making a behavioral decision. The action moves
+        to no defined end state; it is simply abandoned. A pending
+        on_idle wake is cancelled as well: a removed agent never wakes.
+
+        If your action holds external resources (e.g., a Resource slot,
+        a reservation, a lock), override remove() and call
+        self.cancel_action() before super().remove() to ensure
+        on_interrupt() fires and cleanup logic runs:
+
+            def remove(self):
+                self.cancel_action()  # Fires on_interrupt for cleanup
+                super().remove()
+
+        Notes:
+            This is a deliberate design choice. The default silent
+            cleanup is safe and avoids callbacks touching agent state
+            during teardown. Models that need cleanup should opt in
+            explicitly.
+        """
+        if self.current_action is not None:
+            self.current_action._cancel_event()  # Silent cleanup, no callback
+            self.current_action = None
+
+        if self._wake_event is not None:
+            self._wake_event.cancel()
+            self._wake_event = None
+            self._wake_previous = None
+
+        super().remove()
+
+    def start_action(self, action: Action) -> Action:
+        """Start performing an action.
+
+        The action must be in PENDING or INTERRUPTED state and the agent
+        must not be currently performing another action.
+
+        If one of the action's start requirements does not hold, the action moves
+        to FAILED instead of starting and the agent stays idle. Check
+        action.has_failed rather than assuming the action is running.
+
+        Args:
+            action: The Action to perform. Must have been created with
+                this agent as its agent.
+
+        Returns:
+            The started Action.
+
+        Raises:
+            ValueError: If the agent is already performing an action,
+                or if the action doesn't belong to this agent.
+        """
+        if self.current_action is not None:
+            raise ValueError(
+                f"Agent {self.unique_id} is already performing an action "
+                f"({self.current_action!r}). Use interrupt_for() or "
+                f"cancel_action() first."
+            )
+
+        if action.agent is not self:
+            raise ValueError(
+                f"Action's agent (id={action.agent.unique_id}) does not match "
+                f"this agent (id={self.unique_id})."
+            )
+
+        self.current_action = action
+        action.start()
+
+        # If the action completed instantly (duration=0), start() already
+        # called _do_complete which cleared current_action via the Action.
+        return action
+
+    def should_interrupt(self, current: Action, incoming: Action) -> bool:
+        """Decide whether an incoming action may preempt the current one.
+
+        Consulted by interrupt_for() whenever the agent is busy, with both
+        priorities already resolved. Override to encode preemption policy,
+        e.g. comparing action names or agent state instead of priorities.
+
+        Args:
+            current: The action the agent is performing.
+            incoming: The action that wants to replace it.
+
+        Returns:
+            True to attempt the interruption, False to refuse it.
+
+        Notes:
+            Returning True cannot override the interruptible flag; use
+            cancel_action() to force. This hook decides policy, the flag
+            stays a hard property of the action.
+        """
+        return current.interruptible and incoming.priority >= current.priority
+
+    def interrupt_for(self, new_action: Action) -> bool:
+        """Interrupt the current action and start a new one.
+
+        If there is no current action, simply starts the new one. Otherwise
+        should_interrupt(current, incoming) decides whether to preempt.
+
+        Args:
+            new_action: The Action to perform instead.
+
+        Returns:
+            True if the new action was started. False if should_interrupt
+            refused, the current action is non-interruptible, or the new
+            action failed its start requirements.
+
+        Notes:
+            The False cases differ in what they leave behind. A refusal
+            changes nothing. A failed requirement does not roll the
+            interruption back: the old action is already INTERRUPTED and
+            the agent is left idle, since whether to resume it is the
+            model's decision.
+        """
+        if self.current_action is not None:
+            new_action._resolve_priority()
+            if not self.should_interrupt(self.current_action, new_action):
+                return False
+            if not self.current_action.interrupt():
+                return False
+                # interrupt() already cleared current_action
+
+        self.start_action(new_action)
+        return not new_action.has_failed
+
+    def cancel_action(self) -> bool:
+        """Cancel the current action, ignoring interruptible flag.
+
+        Calls on_interrupt with partial progress. Returns False only if
+        there is no current action.
+
+        Returns:
+            True if an action was cancelled, False if idle.
+        """
+        if self.current_action is None:
+            return False
+
+        self.current_action.cancel()
+        # cancel() already cleared current_action
+        return True
+
+    @property
+    def is_busy(self) -> bool:
+        """Whether the agent is currently performing an action."""
+        return self.current_action is not None
+
+    def on_idle(self, previous: Action | None) -> None:
+        """Called when the agent's action has ended and nothing replaced it.
+
+        Fires for every way an action can end -- completion, interruption,
+        cancellation, failure -- as a zero-delay ``Priority.LOW`` event
+        rather than synchronously, so every agent finishing at time t
+        decides after all completions at t have run.
+
+        Override it to choose what to do next, typically by starting or
+        resuming an action. The default does nothing, and nothing is
+        resumed automatically: an interrupted action stays interrupted
+        unless this hook (or other model code) restarts it.
+
+        Args:
+            previous: The action that just ended, in its final state
+                (COMPLETED, INTERRUPTED, or FAILED). None is reserved for
+                wakes not caused by an action ending; no built-in trigger
+                sends it today.
+
+        Notes:
+            At most one wake fires per agent per model time, so a
+            zero-duration action started here cannot re-trigger the hook
+            in the same instant; a wake dropped by this guard is logged
+            at DEBUG level. The wake is skipped when the agent is
+            busy again by the time the event runs -- interrupt_for()
+            refills the slot synchronously, so no idle gap ever existed.
+            If several actions end before the wake runs, they coalesce
+            into one call and ``previous`` is the latest of them.
+        """
+
+    def _schedule_wake(self, previous: Action | None) -> None:
+        """Queue the deferred on_idle event, coalescing repeats.
+
+        Called by Action._release_agent whenever this agent's slot is
+        cleared. If a wake is already pending, or one already fired at
+        the current model time, no second event is queued -- only
+        ``previous`` is brought up to date. A wake dropped by the
+        once-per-time guard is logged at DEBUG level.
+        """
+        self._wake_previous = previous
+        if self._wake_event is not None:
+            return
+        if self._last_wake_time == self.model.time:
+            _mesa_logger.debug(
+                f"suppressed repeat on_idle wake for agent {self.unique_id} "
+                f"at time {self.model.time} (ending action: {previous!r})"
+            )
+            return
+        self._wake_event = self.model.schedule_event(
+            self._fire_wake, after=0.0, priority=Priority.LOW
+        )
+
+    def _fire_wake(self) -> None:
+        """Run the pending wake: call on_idle if the agent is still free."""
+        previous = self._wake_previous
+        self._wake_event = None
+        self._wake_previous = None
+        if self.current_action is not None:
+            return
+        # Recorded only when on_idle actually runs, so a busy skip does not
+        # suppress a later release at the same model time.
+        self._last_wake_time = self.model.time
+        self.on_idle(previous)

--- a/tests/experimental/test_actions.py
+++ b/tests/experimental/test_actions.py
@@ -6,9 +6,13 @@ import logging
 import pytest
 
 from mesa import Agent, Model
-from mesa.experimental.actions import Action, ActionState
+from mesa.experimental.actions import Action, ActionState, HasActions
 
 # --- Helpers ---
+
+
+class ActionAgent(HasActions, Agent):
+    """Agent with action support, as models combine it."""
 
 
 class TrackedAction(Action):
@@ -42,7 +46,7 @@ class TrackedAction(Action):
 
 def make_model_and_agent():
     model = Model()
-    agent = Agent(model)
+    agent = ActionAgent(model)
     return model, agent
 
 
@@ -546,7 +550,7 @@ class TestErrorHandling:
 
     def test_start_wrong_agent_raises(self):
         model, agent1 = make_model_and_agent()
-        agent2 = Agent(model)
+        agent2 = ActionAgent(model)
         action = TrackedAction(agent1, duration=5.0)
 
         with pytest.raises(ValueError, match="does not match"):
@@ -571,6 +575,33 @@ class TestErrorHandling:
     def test_cancel_idle_returns_false(self):
         _model, agent = make_model_and_agent()
         assert agent.cancel_action() is False
+
+    def test_action_requires_has_actions_agent(self):
+        """A plain Agent without the mixin is rejected up front."""
+        model = Model()
+        plain = Agent(model)
+
+        with pytest.raises(TypeError, match="HasActions"):
+            Action(plain)
+
+    def test_mixin_combines_with_other_agent_bases(self):
+        """Cooperative __init__ lets the mixin ride any Agent subclass."""
+        from mesa.discrete_space import CellAgent, OrthogonalMooreGrid  # noqa: PLC0415
+
+        class Grazer(HasActions, CellAgent):
+            pass
+
+        model = Model()
+        grid = OrthogonalMooreGrid((3, 3), random=model.random)
+        agent = Grazer(model)
+        agent.cell = grid[(1, 1)]
+
+        action = agent.start_action(TrackedAction(agent, duration=2.0))
+        model.run_for(2)
+
+        assert action.completed
+        assert not agent.is_busy
+        assert agent.cell is grid[(1, 1)]
 
 
 # --- Callable duration and priority ---
@@ -692,7 +723,7 @@ class TestAgentRemoval:
     def test_remove_with_explicit_cleanup(self):
         """Users can opt into on_interrupt by calling cancel_action first."""
         model = Model()
-        agent = Agent(model)
+        agent = ActionAgent(model)
         action = TrackedAction(agent, duration=10.0)
 
         agent.start_action(action)
@@ -1065,7 +1096,7 @@ class TestShouldInterrupt:
         _model, agent = make_model_and_agent()
         consulted = []
 
-        class Watcher(Agent):
+        class Watcher(ActionAgent):
             def should_interrupt(self, current, incoming):
                 consulted.append((current, incoming))
                 return super().should_interrupt(current, incoming)
@@ -1081,7 +1112,7 @@ class TestShouldInterrupt:
         """A subclass can ignore priorities entirely."""
         model = Model()
 
-        class Stubborn(Agent):
+        class Stubborn(ActionAgent):
             def should_interrupt(self, current, incoming):
                 return incoming.name == "Flee"
 
@@ -1095,7 +1126,7 @@ class TestShouldInterrupt:
         """Returning True attempts the interruption; the flag still refuses."""
         model = Model()
 
-        class Pushy(Agent):
+        class Pushy(ActionAgent):
             def should_interrupt(self, current, incoming):
                 return True
 
@@ -1114,7 +1145,7 @@ class TestRealisticScenarios:
     def test_sheep_forage_flee_resume(self):
         """Sheep forages, flees from predator, resumes foraging."""
         model = Model()
-        sheep = Agent(model)
+        sheep = ActionAgent(model)
         sheep.energy = 50.0
         sheep.alive = True
 
@@ -1167,7 +1198,7 @@ class TestRealisticScenarios:
     def test_sequential_actions(self):
         """Agent performs multiple actions in sequence."""
         model = Model()
-        agent = Agent(model)
+        agent = ActionAgent(model)
         agent.log = []
 
         class LogAction(Action):
@@ -1188,7 +1219,7 @@ class TestRealisticScenarios:
     def test_flee_non_interruptible_protects(self):
         """A fleeing agent can't be interrupted."""
         model = Model()
-        agent = Agent(model)
+        agent = ActionAgent(model)
 
         flee = Action(agent, duration=3.0, interruptible=False)
         distraction = TrackedAction(agent, duration=1.0)
@@ -1205,7 +1236,7 @@ class TestRealisticScenarios:
     def test_worker_interrupted_resumes_task(self):
         """Worker on a task, interrupted by meeting, resumes task."""
         model = Model()
-        worker = Agent(model)
+        worker = ActionAgent(model)
         worker.log = []
 
         class Task(Action):
@@ -1255,7 +1286,7 @@ class TestRealisticScenarios:
         """
         model = Model()
         patch = {"servings": 1}
-        first, second = Agent(model), Agent(model)
+        first, second = ActionAgent(model), ActionAgent(model)
         first.energy = second.energy = 0.0
         second.looked_elsewhere = False
 
@@ -1290,7 +1321,7 @@ class TestRealisticScenarios:
     def test_completion_requirement_for_a_condition_nobody_can_claim(self):
         """Market hours cannot be reserved, so the check belongs at completion."""
         model = Model()
-        trader = Agent(model)
+        trader = ActionAgent(model)
         trader.filled = False
         market = {"open": True}
 
@@ -1317,7 +1348,7 @@ class TestRealisticScenarios:
 # --- Wake contract (on_idle) ---
 
 
-class IdleRecorder(Agent):
+class IdleRecorder(ActionAgent):
     """Agent that records every on_idle wake with the state it saw."""
 
     def __init__(self, model):
@@ -1415,7 +1446,7 @@ class TestOnIdle:
         # hangs rather than fails.
         model = Model()
 
-        class Chain(Agent):
+        class Chain(ActionAgent):
             def __init__(self, model):
                 super().__init__(model)
                 self.idle_calls = 0
@@ -1433,13 +1464,15 @@ class TestOnIdle:
     def test_suppressed_wake_is_logged_at_debug(self, caplog):
         model = Model()
 
-        class Chain(Agent):
+        class Chain(ActionAgent):
             def on_idle(self, previous):
                 self.start_action(Action(self, duration=0.0))
 
         agent = Chain(model)
         agent.start_action(Action(agent, duration=0.0))
-        with caplog.at_level(logging.DEBUG, logger="MESA.mesa.agent"):
+        with caplog.at_level(
+            logging.DEBUG, logger="MESA.mesa.experimental.actions.actions"
+        ):
             model.run_for(1)
 
         assert "suppressed repeat on_idle wake" in caplog.text
@@ -1448,7 +1481,7 @@ class TestOnIdle:
     def test_agent_chains_actions_across_time(self):
         model = Model()
 
-        class Worker(Agent):
+        class Worker(ActionAgent):
             def __init__(self, model):
                 super().__init__(model)
                 self.done = 0
@@ -1467,9 +1500,9 @@ class TestOnIdle:
     def test_wake_runs_after_all_completions_at_that_time(self):
         model = Model()
         observed = []
-        other = TrackedAction(Agent(model), duration=5.0)
+        other = TrackedAction(ActionAgent(model), duration=5.0)
 
-        class Nosy(Agent):
+        class Nosy(ActionAgent):
             def on_idle(self, previous):
                 observed.append(other.state)
 


### PR DESCRIPTION
### Summary
Moves the agent-side action API off core `Agent` into a `HasActions` mixin in `mesa.experimental.actions`. `Agent` shrinks by ~210 lines; models opt in with `class Wolf(HasActions, CellAgent)`. Public import path: `from mesa.experimental.actions import Action, HasActions`. Follows up on @quaquel's composition question in #3805, agreed there as a future PR and recorded as the open placement decision in #3798.

### Motive
Two problems with the status quo: every new hook grew the base `Agent` class ("the larger the base Agent class becomes, the steeper the learning curve"), and `start_action` & co. sat on *stable* `Agent` while `Action` itself is experimental. With the mixin, the whole cluster is experimental together, and models that don't use actions don't carry the API.

### Implementation
- `HasActions` lives in `actions.py` alongside `Action` and carries the cluster unchanged: `current_action`, `start_action`/`interrupt_for`/`cancel_action`, `should_interrupt`, `is_busy`, `on_idle` with the deferred-wake machinery (including the DEBUG log from #3833), and a `remove()` override that does action/wake cleanup before `super().remove()`. Cooperative `__init__`, mixin listed first.
- `Action.__init__` now rejects a mixin-less agent up front with an actionable `TypeError`, instead of failing later on a missing attribute.
- `Agent` keeps two deliberate traces: `"current_action"` stays in `_repr_excluded_fields` (a repr filter two existing tests rely on, not API surface).
- Tests run through `ActionAgent(HasActions, Agent)` as models will combine it; new tests pin the `TypeError` and composition with `CellAgent` on a real `OrthogonalMooreGrid`.

### Usage Examples
```python
from mesa.discrete_space import CellAgent
from mesa.experimental.actions import Action, HasActions


class Graze(Action):
    def __init__(self, sheep):
        super().__init__(sheep, duration=5.0)

    def on_complete(self):
        self.agent.energy += 30


class Flee(Action):
    def __init__(self, sheep):
        super().__init__(sheep, duration=2.0, priority=10.0, interruptible=False)


class Sheep(HasActions, CellAgent):
    def on_idle(self, previous):
        if previous is not None and previous.is_resumable:
            self.start_action(previous)      # finish the interrupted graze
        else:
            self.start_action(Graze(self))


# A predator appears mid-graze: should_interrupt compares priorities,
# the graze yields with partial progress, and when the flee completes
# on_idle resumes the remainder.
sheep.interrupt_for(Flee(sheep))
```
